### PR TITLE
Add Resources page with filters and XP formula update

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import Study from './pages/Study';
 import Tasks from './pages/Tasks';
 import Schedule from './pages/Schedule';
 import Insights from './pages/Insights';
+import Resources from './pages/Resources';
 import Privacy from './pages/Privacy';
 import Terms from './pages/Terms';
 import Landing from './pages/Landing';
@@ -20,6 +21,7 @@ import Login from './pages/Login';
 import Signup from './pages/Signup';
 import OnboardingModal from "./components/OnboardingModal";
 import Footer from './components/Footer';
+import { ThemeProvider } from './context/ThemeContext';
 import './styles/index.css';
 
 
@@ -40,8 +42,9 @@ function App() {
     <AuthProvider>
       <GamificationProvider>
         <TimerProvider>
-          <Router>
-            <RouteCleanup />
+          <ThemeProvider>
+            <Router>
+              <RouteCleanup />
             <Routes>
               {/* Public Routes */}
               <Route path="/" element={<div className="flex flex-col min-h-screen"><main className="flex-1"><Landing /><Footer /></main></div>} />
@@ -172,8 +175,24 @@ function App() {
                   </div>
                 </ProtectedRoute>
               } />
+
+              <Route path="/resources" element={
+                <ProtectedRoute>
+                  <div className="flex h-screen bg-[var(--app-bg)]">
+                    <Sidebar />
+                    <div className="flex-1 flex flex-col">
+                      <Navbar />
+                      <main className="flex-1 overflow-auto">
+                        <Resources />
+                        <Footer withSidebar />
+                      </main>
+                    </div>
+                  </div>
+                </ProtectedRoute>
+              } />
             </Routes>
           </Router>
+          </ThemeProvider>
         </TimerProvider>
       </GamificationProvider>
     </AuthProvider>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -17,6 +17,7 @@ const Footer = ({ withSidebar = false }) => {
             <li><Link className="hover:text-[var(--on-primary)]" to="/dashboard">Dashboard</Link></li>
             <li><Link className="hover:text-[var(--on-primary)]" to="/study">Study</Link></li>
             <li><Link className="hover:text-[var(--on-primary)]" to="/subjects">Subjects</Link></li>
+            <li><Link className="hover:text-[var(--on-primary)]" to="/resources">Resources</Link></li>
           </ul>
         </div>
         <div>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -37,7 +37,7 @@ const Navbar = () => {
       
       {/* Center: Page Title & Date */}
       <div className="flex flex-col items-center flex-1 min-w-0">
-        {(["/dashboard","/tasks","/schedule","/subjects","/study","/settings","/insights"].includes(location.pathname)) && (
+        {(["/dashboard","/tasks","/schedule","/subjects","/study","/settings","/insights","/resources"].includes(location.pathname)) && (
           <>
             <span className="text-2xl font-extrabold tracking-widest bg-[white] text-transparent bg-clip-text">
               {location.pathname === "/dashboard" && "DASHBOARD"}
@@ -47,6 +47,7 @@ const Navbar = () => {
               {location.pathname === "/study" && "STUDY"}
               {location.pathname === "/settings" && "SETTINGS"}
               {location.pathname === "/insights" && "INSIGHTS"}
+              {location.pathname === "/resources" && "RESOURCES"}
             </span>
             <span className="text-sm font-medium text-[var(--on-primary-muted)] mt-1">
               {new Date().toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 import {
   FlameIcon, BookIcon, CalendarIcon, ListChecksIcon, BrainIcon,
-  BarChart2Icon, Settings2Icon, LayoutDashboardIcon, BarChart3
+  BarChart2Icon, Settings2Icon, LayoutDashboardIcon, BarChart3, GraduationCap
 } from "lucide-react";
 
 export default function Sidebar() {
@@ -53,6 +53,10 @@ export default function Sidebar() {
         <Link to="/insights" className="flex items-center gap-3 px-6 py-3 focus:outline-none transition theme-hover-primary-10" title="Insights">
           <BarChart3 className="w-5 h-5 text-white" />
           <span className="text-white font-medium opacity-0 group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap">Insights</span>
+        </Link>
+        <Link to="/resources" className="flex items-center gap-3 px-6 py-3 focus:outline-none transition theme-hover-primary-10" title="Resources">
+          <GraduationCap className="w-5 h-5 text-white" />
+          <span className="text-white font-medium opacity-0 group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap">Resources</span>
         </Link>
       </div>
       <Link to="/privacy" className="mt-auto flex items-center gap-3 px-6 py-3 focus:outline-none transition theme-hover-primary-10" title="Settings">

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -28,6 +28,9 @@ export default function Sidebar() {
         <div className="absolute w-16 h-12 flex items-center justify-center transition-opacity duration-300 group-hover:opacity-0" style={{ top: '376px' }}>
           <BarChart3 className="w-5 h-5 text-white" />
         </div>
+        <div className="absolute w-16 h-12 flex items-center justify-center transition-opacity duration-300 group-hover:opacity-0" style={{ top: '432px' }}>
+          <GraduationCap className="w-5 h-5 text-white" />
+        </div>
       </div>
       <div className="flex flex-col gap-2 w-full pt-24 pb-4">
         <Link to="/dashboard" className="flex items-center gap-3 px-6 py-3 focus:outline-none transition theme-hover-primary-10" title="Dashboard">

--- a/src/context/GamificationContext.jsx
+++ b/src/context/GamificationContext.jsx
@@ -229,9 +229,9 @@ export const GamificationProvider = ({ children }) => {
     };
   };
 
-  // Advanced leveling formula: XP needed = 50 × Level^1.5
+  // Leveling formula: XP needed = 10 × Level^1.2
   const getXPForLevel = (level) => {
-    return Math.floor(50 * Math.pow(level, 1.5));
+    return Math.floor(10 * Math.pow(level, 1.2));
   };
 
   // Get cumulative XP required to REACH a given level (level 1 requires 0)

--- a/src/pages/Resources.jsx
+++ b/src/pages/Resources.jsx
@@ -1,0 +1,134 @@
+import React, { useMemo, useState } from "react";
+
+const LEVELS = ["GCSE", "A Level"];
+const SUBJECTS = [
+  "Mathematics",
+  "English Language",
+  "Biology",
+  "Chemistry",
+  "Physics",
+];
+const BOARDS = ["AQA", "Edexcel", "OCR", "WJEC", "Eduqas"];
+
+// Curated resource links to official exam boards (no bonuses, no placeholders)
+const RESOURCE_DATA = [
+  // AQA
+  { level: "GCSE", subject: "Mathematics", board: "AQA", title: "AQA GCSE Maths (8300)", url: "https://www.aqa.org.uk/subjects/mathematics/gcse/mathematics-8300" },
+  { level: "A Level", subject: "Mathematics", board: "AQA", title: "AQA A-level Maths (7357)", url: "https://www.aqa.org.uk/subjects/mathematics/as-and-a-level/mathematics-7357" },
+  { level: "GCSE", subject: "English Language", board: "AQA", title: "AQA GCSE English Language (8700)", url: "https://www.aqa.org.uk/subjects/english/gcse/english-language-8700" },
+  { level: "A Level", subject: "Physics", board: "AQA", title: "AQA A-level Physics (7408)", url: "https://www.aqa.org.uk/subjects/science/as-and-a-level/physics-7408" },
+  { level: "GCSE", subject: "Biology", board: "AQA", title: "AQA GCSE Biology (8461)", url: "https://www.aqa.org.uk/subjects/science/gcse/biology-8461" },
+  { level: "GCSE", subject: "Chemistry", board: "AQA", title: "AQA GCSE Chemistry (8462)", url: "https://www.aqa.org.uk/subjects/science/gcse/chemistry-8462" },
+
+  // Pearson Edexcel
+  { level: "GCSE", subject: "Mathematics", board: "Edexcel", title: "Edexcel GCSE Maths (9-1)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/mathematics-2015.html" },
+  { level: "A Level", subject: "Mathematics", board: "Edexcel", title: "Edexcel A level Maths (2017)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-a-levels/mathematics-2017.html" },
+  { level: "A Level", subject: "Physics", board: "Edexcel", title: "Edexcel A level Physics (2015)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-a-levels/physics-2015.html" },
+  { level: "GCSE", subject: "Biology", board: "Edexcel", title: "Edexcel GCSE Biology (2016)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/biology-2016.html" },
+  { level: "GCSE", subject: "Chemistry", board: "Edexcel", title: "Edexcel GCSE Chemistry (2016)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/chemistry-2016.html" },
+  { level: "GCSE", subject: "English Language", board: "Edexcel", title: "Edexcel GCSE English Language (2015)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/english-language-2015.html" },
+
+  // OCR
+  { level: "GCSE", subject: "Mathematics", board: "OCR", title: "OCR GCSE Maths (J560)", url: "https://www.ocr.org.uk/qualifications/gcse/mathematics-j560-from-2015/" },
+  { level: "A Level", subject: "Mathematics", board: "OCR", title: "OCR A Level Maths (A) (H230/H240)", url: "https://www.ocr.org.uk/qualifications/as-and-a-level/mathematics-a-h230-h240-from-2017/" },
+  { level: "A Level", subject: "Physics", board: "OCR", title: "OCR A Level Physics (A) (H156/H556)", url: "https://www.ocr.org.uk/qualifications/as-and-a-level/physics-a-h156-h556-from-2015/" },
+  { level: "GCSE", subject: "Biology", board: "OCR", title: "OCR GCSE Biology A (J247)", url: "https://www.ocr.org.uk/qualifications/gcse/biology-a-j247-from-2016/" },
+  { level: "GCSE", subject: "Chemistry", board: "OCR", title: "OCR GCSE Chemistry A (J248)", url: "https://www.ocr.org.uk/qualifications/gcse/chemistry-a-j248-from-2016/" },
+  { level: "GCSE", subject: "English Language", board: "OCR", title: "OCR GCSE English Language (J351)", url: "https://www.ocr.org.uk/qualifications/gcse/english-language-j351-from-2015/" },
+
+  // WJEC / Eduqas
+  { level: "GCSE", subject: "Mathematics", board: "WJEC", title: "WJEC GCSE Mathematics", url: "https://qualifications.wjec.org.uk/qualifications/mathematics-gcse/" },
+  { level: "A Level", subject: "Biology", board: "Eduqas", title: "Eduqas AS/A Level Biology", url: "https://www.eduqas.co.uk/qualifications/biology-as-a-level/" },
+  { level: "A Level", subject: "Chemistry", board: "Eduqas", title: "Eduqas AS/A Level Chemistry", url: "https://www.eduqas.co.uk/qualifications/chemistry-as-a-level/" },
+  { level: "GCSE", subject: "English Language", board: "Eduqas", title: "Eduqas GCSE English Language", url: "https://www.eduqas.co.uk/qualifications/english-language-gcse/" },
+];
+
+export default function Resources() {
+  const [level, setLevel] = useState("All");
+  const [subject, setSubject] = useState("All");
+  const [board, setBoard] = useState("All");
+
+  const filtered = useMemo(() => {
+    return RESOURCE_DATA.filter((r) =>
+      (level === "All" || r.level === level) &&
+      (subject === "All" || r.subject === subject) &&
+      (board === "All" || r.board === board)
+    );
+  }, [level, subject, board]);
+
+  return (
+    <div className="min-h-screen mt-20 p-6" style={{ backgroundColor: "var(--app-bg)" }}>
+      <div className="max-w-7xl mx-auto">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold mb-2" style={{ color: "var(--nav-to)" }}>Resources</h1>
+          <p className="text-gray-600">Find syllabus pages, past papers, specifications and official guidance from UK exam boards. Filter by level, subject and board.</p>
+        </div>
+
+        {/* Filters */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+          <div className="flex flex-col">
+            <label className="text-sm mb-1 text-gray-700">Level</label>
+            <select
+              value={level}
+              onChange={(e) => setLevel(e.target.value)}
+              className="rounded-lg border px-3 py-2 bg-white"
+            >
+              <option>All</option>
+              {LEVELS.map((l) => (
+                <option key={l} value={l}>{l}</option>
+              ))}
+            </select>
+          </div>
+          <div className="flex flex-col">
+            <label className="text-sm mb-1 text-gray-700">Subject</label>
+            <select
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              className="rounded-lg border px-3 py-2 bg-white"
+            >
+              <option>All</option>
+              {SUBJECTS.map((s) => (
+                <option key={s} value={s}>{s}</option>
+              ))}
+            </select>
+          </div>
+          <div className="flex flex-col">
+            <label className="text-sm mb-1 text-gray-700">Exam Board</label>
+            <select
+              value={board}
+              onChange={(e) => setBoard(e.target.value)}
+              className="rounded-lg border px-3 py-2 bg-white"
+            >
+              <option>All</option>
+              {BOARDS.map((b) => (
+                <option key={b} value={b}>{b}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Results */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filtered.map((r) => (
+            <a
+              key={`${r.board}-${r.level}-${r.subject}-${r.url}`}
+              href={r.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-2xl p-4 border hover:shadow transition bg-white flex flex-col"
+              style={{ borderColor: "#e5e7eb" }}
+            >
+              <div className="text-xs font-semibold mb-1 text-gray-500">{r.level} • {r.subject} • {r.board}</div>
+              <div className="text-lg font-semibold mb-2" style={{ color: "var(--primary)" }}>{r.title}</div>
+              <div className="mt-auto text-sm text-blue-600">Open official page →</div>
+            </a>
+          ))}
+        </div>
+
+        {filtered.length === 0 && (
+          <div className="text-gray-500 text-center py-16">No resources found. Try different filters.</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Resources.jsx
+++ b/src/pages/Resources.jsx
@@ -17,6 +17,14 @@ const TYPES = [
 // Recent series years commonly available online
 const YEARS = ["All", 2024, 2023, 2022, 2021, 2020, 2019, 2018];
 
+// Replace unicode dashes/bullets that might render as replacement chars on some systems
+function sanitize(text) {
+  return String(text)
+    .replace(/\u2014|\u2013|\u2212|\u2043/g, "-") // various dashes to hyphen
+    .replace(/\u2022/g, "-") // bullet to hyphen
+    .replace(/\s+-\s+/g, " - ");
+}
+
 // Specification pages (official exam board specs)
 const SPEC_LINKS = [
   // AQA (specifications)
@@ -53,34 +61,34 @@ const SPEC_LINKS = [
 // Past paper hubs (official board pages that contain all years/series)
 const PAST_BASES = [
   // AQA
-  { level: "GCSE", subject: "Mathematics", board: "AQA", title: "AQA GCSE Maths — Past papers & mark schemes", url: "https://www.aqa.org.uk/subjects/mathematics/gcse/mathematics-8300/assessment-resources" },
-  { level: "A Level", subject: "Mathematics", board: "AQA", title: "AQA A-level Maths — Past papers & mark schemes", url: "https://www.aqa.org.uk/subjects/mathematics/as-and-a-level/mathematics-7357/assessment-resources" },
-  { level: "GCSE", subject: "English Language", board: "AQA", title: "AQA GCSE English Language — Past papers & mark schemes", url: "https://www.aqa.org.uk/subjects/english/gcse/english-language-8700/assessment-resources" },
-  { level: "GCSE", subject: "Biology", board: "AQA", title: "AQA GCSE Biology — Past papers & mark schemes", url: "https://www.aqa.org.uk/subjects/science/gcse/biology-8461/assessment-resources" },
-  { level: "GCSE", subject: "Chemistry", board: "AQA", title: "AQA GCSE Chemistry — Past papers & mark schemes", url: "https://www.aqa.org.uk/subjects/science/gcse/chemistry-8462/assessment-resources" },
-  { level: "A Level", subject: "Physics", board: "AQA", title: "AQA A-level Physics — Past papers & mark schemes", url: "https://www.aqa.org.uk/subjects/science/as-and-a-level/physics-7408/assessment-resources" },
+  { level: "GCSE", subject: "Mathematics", board: "AQA", title: "AQA GCSE Maths - Past papers & mark schemes", url: "https://www.aqa.org.uk/subjects/mathematics/gcse/mathematics-8300/assessment-resources" },
+  { level: "A Level", subject: "Mathematics", board: "AQA", title: "AQA A-level Maths - Past papers & mark schemes", url: "https://www.aqa.org.uk/subjects/mathematics/as-and-a-level/mathematics-7357/assessment-resources" },
+  { level: "GCSE", subject: "English Language", board: "AQA", title: "AQA GCSE English Language - Past papers & mark schemes", url: "https://www.aqa.org.uk/subjects/english/gcse/english-language-8700/assessment-resources" },
+  { level: "GCSE", subject: "Biology", board: "AQA", title: "AQA GCSE Biology - Past papers & mark schemes", url: "https://www.aqa.org.uk/subjects/science/gcse/biology-8461/assessment-resources" },
+  { level: "GCSE", subject: "Chemistry", board: "AQA", title: "AQA GCSE Chemistry - Past papers & mark schemes", url: "https://www.aqa.org.uk/subjects/science/gcse/chemistry-8462/assessment-resources" },
+  { level: "A Level", subject: "Physics", board: "AQA", title: "AQA A-level Physics - Past papers & mark schemes", url: "https://www.aqa.org.uk/subjects/science/as-and-a-level/physics-7408/assessment-resources" },
 
   // Edexcel (Pearson) — general exam materials pages include past papers
-  { level: "GCSE", subject: "Mathematics", board: "Edexcel", title: "Edexcel GCSE Maths — Exam materials (past papers)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/mathematics-2015.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FExam-materials" },
-  { level: "A Level", subject: "Mathematics", board: "Edexcel", title: "Edexcel A level Maths — Exam materials (past papers)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-a-levels/mathematics-2017.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FExam-materials" },
-  { level: "A Level", subject: "Physics", board: "Edexcel", title: "Edexcel A level Physics — Exam materials (past papers)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-a-levels/physics-2015.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FExam-materials" },
-  { level: "GCSE", subject: "Biology", board: "Edexcel", title: "Edexcel GCSE Biology — Exam materials (past papers)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/biology-2016.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FExam-materials" },
-  { level: "GCSE", subject: "Chemistry", board: "Edexcel", title: "Edexcel GCSE Chemistry — Exam materials (past papers)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/chemistry-2016.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FExam-materials" },
-  { level: "GCSE", subject: "English Language", board: "Edexcel", title: "Edexcel GCSE English Language — Exam materials (past papers)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/english-language-2015.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FExam-materials" },
+  { level: "GCSE", subject: "Mathematics", board: "Edexcel", title: "Edexcel GCSE Maths - Exam materials (past papers)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/mathematics-2015.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FExam-materials" },
+  { level: "A Level", subject: "Mathematics", board: "Edexcel", title: "Edexcel A level Maths - Exam materials (past papers)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-a-levels/mathematics-2017.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FExam-materials" },
+  { level: "A Level", subject: "Physics", board: "Edexcel", title: "Edexcel A level Physics - Exam materials (past papers)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-a-levels/physics-2015.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FExam-materials" },
+  { level: "GCSE", subject: "Biology", board: "Edexcel", title: "Edexcel GCSE Biology - Exam materials (past papers)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/biology-2016.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FExam-materials" },
+  { level: "GCSE", subject: "Chemistry", board: "Edexcel", title: "Edexcel GCSE Chemistry - Exam materials (past papers)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/chemistry-2016.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FExam-materials" },
+  { level: "GCSE", subject: "English Language", board: "Edexcel", title: "Edexcel GCSE English Language - Exam materials (past papers)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/english-language-2015.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FExam-materials" },
 
   // OCR — assessment pages hold past papers
-  { level: "GCSE", subject: "Mathematics", board: "OCR", title: "OCR GCSE Maths — Past papers, mark schemes, reports", url: "https://www.ocr.org.uk/qualifications/gcse/mathematics-j560-from-2015/assessment/" },
-  { level: "A Level", subject: "Mathematics", board: "OCR", title: "OCR A Level Maths — Past papers, mark schemes, reports", url: "https://www.ocr.org.uk/qualifications/as-and-a-level/mathematics-a-h230-h240-from-2017/assessment/" },
-  { level: "A Level", subject: "Physics", board: "OCR", title: "OCR A Level Physics — Past papers, mark schemes, reports", url: "https://www.ocr.org.uk/qualifications/as-and-a-level/physics-a-h156-h556-from-2015/assessment/" },
-  { level: "GCSE", subject: "Biology", board: "OCR", title: "OCR GCSE Biology A — Past papers, mark schemes, reports", url: "https://www.ocr.org.uk/qualifications/gcse/biology-a-j247-from-2016/assessment/" },
-  { level: "GCSE", subject: "Chemistry", board: "OCR", title: "OCR GCSE Chemistry A — Past papers, mark schemes, reports", url: "https://www.ocr.org.uk/qualifications/gcse/chemistry-a-j248-from-2016/assessment/" },
-  { level: "GCSE", subject: "English Language", board: "OCR", title: "OCR GCSE English Language — Past papers, mark schemes, reports", url: "https://www.ocr.org.uk/qualifications/gcse/english-language-j351-from-2015/assessment/" },
+  { level: "GCSE", subject: "Mathematics", board: "OCR", title: "OCR GCSE Maths - Past papers, mark schemes, reports", url: "https://www.ocr.org.uk/qualifications/gcse/mathematics-j560-from-2015/assessment/" },
+  { level: "A Level", subject: "Mathematics", board: "OCR", title: "OCR A Level Maths - Past papers, mark schemes, reports", url: "https://www.ocr.org.uk/qualifications/as-and-a-level/mathematics-a-h230-h240-from-2017/assessment/" },
+  { level: "A Level", subject: "Physics", board: "OCR", title: "OCR A Level Physics - Past papers, mark schemes, reports", url: "https://www.ocr.org.uk/qualifications/as-and-a-level/physics-a-h156-h556-from-2015/assessment/" },
+  { level: "GCSE", subject: "Biology", board: "OCR", title: "OCR GCSE Biology A - Past papers, mark schemes, reports", url: "https://www.ocr.org.uk/qualifications/gcse/biology-a-j247-from-2016/assessment/" },
+  { level: "GCSE", subject: "Chemistry", board: "OCR", title: "OCR GCSE Chemistry A - Past papers, mark schemes, reports", url: "https://www.ocr.org.uk/qualifications/gcse/chemistry-a-j248-from-2016/assessment/" },
+  { level: "GCSE", subject: "English Language", board: "OCR", title: "OCR GCSE English Language - Past papers, mark schemes, reports", url: "https://www.ocr.org.uk/qualifications/gcse/english-language-j351-from-2015/assessment/" },
 
   // WJEC / Eduqas
-  { level: "GCSE", subject: "Mathematics", board: "WJEC", title: "WJEC GCSE Maths — Past papers", url: "https://qualifications.wjec.org.uk/qualifications/mathematics-gcse/assessment/" },
-  { level: "A Level", subject: "Biology", board: "Eduqas", title: "Eduqas AS/A Level Biology — Past papers", url: "https://www.eduqas.co.uk/qualifications/biology-as-a-level/#tab_assessmentresources" },
-  { level: "A Level", subject: "Chemistry", board: "Eduqas", title: "Eduqas AS/A Level Chemistry — Past papers", url: "https://www.eduqas.co.uk/qualifications/chemistry-as-a-level/#tab_assessmentresources" },
-  { level: "GCSE", subject: "English Language", board: "Eduqas", title: "Eduqas GCSE English Language — Past papers", url: "https://www.eduqas.co.uk/qualifications/english-language-gcse/#tab_assessmentresources" },
+  { level: "GCSE", subject: "Mathematics", board: "WJEC", title: "WJEC GCSE Maths - Past papers", url: "https://qualifications.wjec.org.uk/qualifications/mathematics-gcse/assessment/" },
+  { level: "A Level", subject: "Biology", board: "Eduqas", title: "Eduqas AS/A Level Biology - Past papers", url: "https://www.eduqas.co.uk/qualifications/biology-as-a-level/#tab_assessmentresources" },
+  { level: "A Level", subject: "Chemistry", board: "Eduqas", title: "Eduqas AS/A Level Chemistry - Past papers", url: "https://www.eduqas.co.uk/qualifications/chemistry-as-a-level/#tab_assessmentresources" },
+  { level: "GCSE", subject: "English Language", board: "Eduqas", title: "Eduqas GCSE English Language - Past papers", url: "https://www.eduqas.co.uk/qualifications/english-language-gcse/#tab_assessmentresources" },
 ];
 
 function expandPastPapers() {
@@ -88,7 +96,7 @@ function expandPastPapers() {
   for (const base of PAST_BASES) {
     for (const y of YEARS) {
       if (y === "All") continue;
-      entries.push({ ...base, title: `${base.title} — ${y}`, type: "past_paper", year: y });
+      entries.push({ ...base, title: `${base.title} - ${y}`, type: "past_paper", year: y });
     }
     // Also include a catch-all entry without year for users who didn't pick a year
     entries.push({ ...base, type: "past_paper", year: null });
@@ -107,6 +115,7 @@ export default function Resources() {
   const [board, setBoard] = useState("All");
   const [type, setType] = useState("all");
   const [year, setYear] = useState("All");
+  const [view, setView] = useState("grid"); // grid | list
 
   const filtered = useMemo(() => {
     return RESOURCE_DATA.filter((r) =>
@@ -121,9 +130,30 @@ export default function Resources() {
   return (
     <div className="min-h-screen mt-20 p-6" style={{ backgroundColor: "var(--app-bg)" }}>
       <div className="max-w-7xl mx-auto">
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold mb-2" style={{ color: "var(--nav-to)" }}>Resources</h1>
-          <p className="text-gray-600">Find syllabus pages, past papers, specifications and official guidance from UK exam boards. Filter by level, subject, board, type, and year.</p>
+        <div className="mb-8 flex items-start justify-between gap-4 flex-wrap">
+          <div>
+            <h1 className="text-3xl font-bold mb-2" style={{ color: "var(--nav-to)" }}>Resources</h1>
+            <p className="text-gray-600">Find syllabus pages, past papers, specifications and official guidance from UK exam boards. Filter by level, subject, board, type, and year.</p>
+          </div>
+          {/* View toggle */}
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              aria-pressed={view === "grid"}
+              onClick={() => setView("grid")}
+              className={`px-3 py-2 rounded-lg border text-sm ${view === "grid" ? "bg-[var(--primary)] text-white border-transparent" : "bg-white text-gray-700 border-gray-200"}`}
+            >
+              Grid
+            </button>
+            <button
+              type="button"
+              aria-pressed={view === "list"}
+              onClick={() => setView("list")}
+              className={`px-3 py-2 rounded-lg border text-sm ${view === "list" ? "bg-[var(--primary)] text-white border-transparent" : "bg-white text-gray-700 border-gray-200"}`}
+            >
+              List
+            </button>
+          </div>
         </div>
 
         {/* Filters */}
@@ -164,24 +194,42 @@ export default function Resources() {
         </div>
 
         {/* Results */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {filtered.map((r) => (
-            <a
-              key={`${r.board}-${r.level}-${r.subject}-${r.type}-${r.year ?? "any"}-${r.url}`}
-              href={r.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-2xl p-4 border hover:shadow transition bg-white flex flex-col"
-              style={{ borderColor: "#e5e7eb" }}
-            >
-              <div className="text-xs font-semibold mb-1 text-gray-500">
-                {r.level} • {r.subject} • {r.board} ��� {r.type === "past_paper" ? `Past papers${r.year ? ` • ${r.year}` : ""}` : "Specification"}
-              </div>
-              <div className="text-lg font-semibold mb-2" style={{ color: "var(--primary)" }}>{r.title}</div>
-              <div className="mt-auto text-sm text-blue-600">Open official page →</div>
-            </a>
-          ))}
-        </div>
+        {view === "grid" ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {filtered.map((r) => (
+              <a
+                key={`${r.board}-${r.level}-${r.subject}-${r.type}-${r.year ?? "any"}-${r.url}`}
+                href={r.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-2xl p-4 border hover:shadow transition bg-white flex flex-col"
+                style={{ borderColor: "#e5e7eb" }}
+              >
+                <div className="text-xs font-semibold mb-1 text-gray-500">
+                  {sanitize(r.level)} - {sanitize(r.subject)} - {sanitize(r.board)} - {r.type === "past_paper" ? `Past papers${r.year ? ` - ${r.year}` : ""}` : "Specification"}
+                </div>
+                <div className="text-lg font-semibold mb-2" style={{ color: "var(--primary)" }}>{sanitize(r.title)}</div>
+                <div className="mt-auto text-sm text-blue-600">Open official page →</div>
+              </a>
+            ))}
+          </div>
+        ) : (
+          <div className="bg-white rounded-2xl border" style={{ borderColor: "#e5e7eb" }}>
+            <ul className="divide-y" style={{ borderColor: "#e5e7eb" }}>
+              {filtered.map((r) => (
+                <li key={`${r.board}-${r.level}-${r.subject}-${r.type}-${r.year ?? "any"}-${r.url}`} className="p-4 hover:bg-gray-50 transition">
+                  <a href={r.url} target="_blank" rel="noopener noreferrer" className="flex flex-col sm:flex-row sm:items-center gap-2">
+                    <span className="text-sm text-gray-500 flex-1">
+                      {sanitize(r.level)} - {sanitize(r.subject)} - {sanitize(r.board)} - {r.type === "past_paper" ? `Past papers${r.year ? ` - ${r.year}` : ""}` : "Specification"}
+                    </span>
+                    <span className="font-semibold" style={{ color: "var(--primary)" }}>{sanitize(r.title)}</span>
+                    <span className="text-blue-600 text-sm">Open →</span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
 
         {filtered.length === 0 && (
           <div className="text-gray-500 text-center py-16">No resources found. Try different filters.</div>

--- a/src/pages/Resources.jsx
+++ b/src/pages/Resources.jsx
@@ -9,100 +9,156 @@ const SUBJECTS = [
   "Physics",
 ];
 const BOARDS = ["AQA", "Edexcel", "OCR", "WJEC", "Eduqas"];
+const TYPES = [
+  { key: "all", label: "All" },
+  { key: "past_paper", label: "Past papers" },
+  { key: "specification", label: "Specification" },
+];
+// Recent series years commonly available online
+const YEARS = ["All", 2024, 2023, 2022, 2021, 2020, 2019, 2018];
 
-// Curated resource links to official exam boards (no bonuses, no placeholders)
-const RESOURCE_DATA = [
+// Specification pages (official exam board specs)
+const SPEC_LINKS = [
+  // AQA (specifications)
+  { level: "GCSE", subject: "Mathematics", board: "AQA", title: "AQA GCSE Maths (8300) — Specification", url: "https://www.aqa.org.uk/subjects/mathematics/gcse/mathematics-8300/specification-at-a-glance", type: "specification" },
+  { level: "A Level", subject: "Mathematics", board: "AQA", title: "AQA A-level Maths (7357) — Specification", url: "https://www.aqa.org.uk/subjects/mathematics/as-and-a-level/mathematics-7357/specification-at-a-glance", type: "specification" },
+  { level: "GCSE", subject: "English Language", board: "AQA", title: "AQA GCSE English Language (8700) — Specification", url: "https://www.aqa.org.uk/subjects/english/gcse/english-language-8700/specification-at-a-glance", type: "specification" },
+  { level: "A Level", subject: "Physics", board: "AQA", title: "AQA A-level Physics (7408) — Specification", url: "https://www.aqa.org.uk/subjects/science/as-and-a-level/physics-7408/specification-at-a-glance", type: "specification" },
+  { level: "GCSE", subject: "Biology", board: "AQA", title: "AQA GCSE Biology (8461) — Specification", url: "https://www.aqa.org.uk/subjects/science/gcse/biology-8461/specification-at-a-glance", type: "specification" },
+  { level: "GCSE", subject: "Chemistry", board: "AQA", title: "AQA GCSE Chemistry (8462) — Specification", url: "https://www.aqa.org.uk/subjects/science/gcse/chemistry-8462/specification-at-a-glance", type: "specification" },
+
+  // Pearson Edexcel (specifications)
+  { level: "GCSE", subject: "Mathematics", board: "Edexcel", title: "Edexcel GCSE Maths (9-1) — Specification", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/mathematics-2015.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FTeaching-and-learning-materials", type: "specification" },
+  { level: "A Level", subject: "Mathematics", board: "Edexcel", title: "Edexcel A level Maths — Specification", url: "https://qualifications.pearson.com/en/qualifications/edexcel-a-levels/mathematics-2017.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FTeaching-and-learning-materials", type: "specification" },
+  { level: "A Level", subject: "Physics", board: "Edexcel", title: "Edexcel A level Physics — Specification", url: "https://qualifications.pearson.com/en/qualifications/edexcel-a-levels/physics-2015.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FTeaching-and-learning-materials", type: "specification" },
+  { level: "GCSE", subject: "Biology", board: "Edexcel", title: "Edexcel GCSE Biology — Specification", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/biology-2016.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FTeaching-and-learning-materials", type: "specification" },
+  { level: "GCSE", subject: "Chemistry", board: "Edexcel", title: "Edexcel GCSE Chemistry — Specification", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/chemistry-2016.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FTeaching-and-learning-materials", type: "specification" },
+  { level: "GCSE", subject: "English Language", board: "Edexcel", title: "Edexcel GCSE English Language — Specification", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/english-language-2015.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FTeaching-and-learning-materials", type: "specification" },
+
+  // OCR (specifications)
+  { level: "GCSE", subject: "Mathematics", board: "OCR", title: "OCR GCSE Maths (J560) — Specification", url: "https://www.ocr.org.uk/qualifications/gcse/mathematics-j560-from-2015/specification-at-a-glance/", type: "specification" },
+  { level: "A Level", subject: "Mathematics", board: "OCR", title: "OCR A Level Maths (A) — Specification", url: "https://www.ocr.org.uk/qualifications/as-and-a-level/mathematics-a-h230-h240-from-2017/specification-at-a-glance/", type: "specification" },
+  { level: "A Level", subject: "Physics", board: "OCR", title: "OCR A Level Physics (A) — Specification", url: "https://www.ocr.org.uk/qualifications/as-and-a-level/physics-a-h156-h556-from-2015/specification-at-a-glance/", type: "specification" },
+  { level: "GCSE", subject: "Biology", board: "OCR", title: "OCR GCSE Biology A (J247) — Specification", url: "https://www.ocr.org.uk/qualifications/gcse/biology-a-j247-from-2016/specification-at-a-glance/", type: "specification" },
+  { level: "GCSE", subject: "Chemistry", board: "OCR", title: "OCR GCSE Chemistry A (J248) — Specification", url: "https://www.ocr.org.uk/qualifications/gcse/chemistry-a-j248-from-2016/specification-at-a-glance/", type: "specification" },
+  { level: "GCSE", subject: "English Language", board: "OCR", title: "OCR GCSE English Language (J351) — Specification", url: "https://www.ocr.org.uk/qualifications/gcse/english-language-j351-from-2015/specification-at-a-glance/", type: "specification" },
+
+  // WJEC / Eduqas (specifications)
+  { level: "GCSE", subject: "Mathematics", board: "WJEC", title: "WJEC GCSE Mathematics — Specification", url: "https://qualifications.wjec.org.uk/qualifications/mathematics-gcse/", type: "specification" },
+  { level: "A Level", subject: "Biology", board: "Eduqas", title: "Eduqas AS/A Level Biology — Specification", url: "https://www.eduqas.co.uk/qualifications/biology-as-a-level/", type: "specification" },
+  { level: "A Level", subject: "Chemistry", board: "Eduqas", title: "Eduqas AS/A Level Chemistry — Specification", url: "https://www.eduqas.co.uk/qualifications/chemistry-as-a-level/", type: "specification" },
+  { level: "GCSE", subject: "English Language", board: "Eduqas", title: "Eduqas GCSE English Language — Specification", url: "https://www.eduqas.co.uk/qualifications/english-language-gcse/", type: "specification" },
+];
+
+// Past paper hubs (official board pages that contain all years/series)
+const PAST_BASES = [
   // AQA
-  { level: "GCSE", subject: "Mathematics", board: "AQA", title: "AQA GCSE Maths (8300)", url: "https://www.aqa.org.uk/subjects/mathematics/gcse/mathematics-8300" },
-  { level: "A Level", subject: "Mathematics", board: "AQA", title: "AQA A-level Maths (7357)", url: "https://www.aqa.org.uk/subjects/mathematics/as-and-a-level/mathematics-7357" },
-  { level: "GCSE", subject: "English Language", board: "AQA", title: "AQA GCSE English Language (8700)", url: "https://www.aqa.org.uk/subjects/english/gcse/english-language-8700" },
-  { level: "A Level", subject: "Physics", board: "AQA", title: "AQA A-level Physics (7408)", url: "https://www.aqa.org.uk/subjects/science/as-and-a-level/physics-7408" },
-  { level: "GCSE", subject: "Biology", board: "AQA", title: "AQA GCSE Biology (8461)", url: "https://www.aqa.org.uk/subjects/science/gcse/biology-8461" },
-  { level: "GCSE", subject: "Chemistry", board: "AQA", title: "AQA GCSE Chemistry (8462)", url: "https://www.aqa.org.uk/subjects/science/gcse/chemistry-8462" },
+  { level: "GCSE", subject: "Mathematics", board: "AQA", title: "AQA GCSE Maths — Past papers & mark schemes", url: "https://www.aqa.org.uk/subjects/mathematics/gcse/mathematics-8300/assessment-resources" },
+  { level: "A Level", subject: "Mathematics", board: "AQA", title: "AQA A-level Maths — Past papers & mark schemes", url: "https://www.aqa.org.uk/subjects/mathematics/as-and-a-level/mathematics-7357/assessment-resources" },
+  { level: "GCSE", subject: "English Language", board: "AQA", title: "AQA GCSE English Language — Past papers & mark schemes", url: "https://www.aqa.org.uk/subjects/english/gcse/english-language-8700/assessment-resources" },
+  { level: "GCSE", subject: "Biology", board: "AQA", title: "AQA GCSE Biology — Past papers & mark schemes", url: "https://www.aqa.org.uk/subjects/science/gcse/biology-8461/assessment-resources" },
+  { level: "GCSE", subject: "Chemistry", board: "AQA", title: "AQA GCSE Chemistry — Past papers & mark schemes", url: "https://www.aqa.org.uk/subjects/science/gcse/chemistry-8462/assessment-resources" },
+  { level: "A Level", subject: "Physics", board: "AQA", title: "AQA A-level Physics — Past papers & mark schemes", url: "https://www.aqa.org.uk/subjects/science/as-and-a-level/physics-7408/assessment-resources" },
 
-  // Pearson Edexcel
-  { level: "GCSE", subject: "Mathematics", board: "Edexcel", title: "Edexcel GCSE Maths (9-1)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/mathematics-2015.html" },
-  { level: "A Level", subject: "Mathematics", board: "Edexcel", title: "Edexcel A level Maths (2017)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-a-levels/mathematics-2017.html" },
-  { level: "A Level", subject: "Physics", board: "Edexcel", title: "Edexcel A level Physics (2015)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-a-levels/physics-2015.html" },
-  { level: "GCSE", subject: "Biology", board: "Edexcel", title: "Edexcel GCSE Biology (2016)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/biology-2016.html" },
-  { level: "GCSE", subject: "Chemistry", board: "Edexcel", title: "Edexcel GCSE Chemistry (2016)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/chemistry-2016.html" },
-  { level: "GCSE", subject: "English Language", board: "Edexcel", title: "Edexcel GCSE English Language (2015)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/english-language-2015.html" },
+  // Edexcel (Pearson) — general exam materials pages include past papers
+  { level: "GCSE", subject: "Mathematics", board: "Edexcel", title: "Edexcel GCSE Maths — Exam materials (past papers)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/mathematics-2015.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FExam-materials" },
+  { level: "A Level", subject: "Mathematics", board: "Edexcel", title: "Edexcel A level Maths — Exam materials (past papers)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-a-levels/mathematics-2017.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FExam-materials" },
+  { level: "A Level", subject: "Physics", board: "Edexcel", title: "Edexcel A level Physics — Exam materials (past papers)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-a-levels/physics-2015.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FExam-materials" },
+  { level: "GCSE", subject: "Biology", board: "Edexcel", title: "Edexcel GCSE Biology — Exam materials (past papers)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/biology-2016.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FExam-materials" },
+  { level: "GCSE", subject: "Chemistry", board: "Edexcel", title: "Edexcel GCSE Chemistry — Exam materials (past papers)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/chemistry-2016.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FExam-materials" },
+  { level: "GCSE", subject: "English Language", board: "Edexcel", title: "Edexcel GCSE English Language — Exam materials (past papers)", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/english-language-2015.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FExam-materials" },
 
-  // OCR
-  { level: "GCSE", subject: "Mathematics", board: "OCR", title: "OCR GCSE Maths (J560)", url: "https://www.ocr.org.uk/qualifications/gcse/mathematics-j560-from-2015/" },
-  { level: "A Level", subject: "Mathematics", board: "OCR", title: "OCR A Level Maths (A) (H230/H240)", url: "https://www.ocr.org.uk/qualifications/as-and-a-level/mathematics-a-h230-h240-from-2017/" },
-  { level: "A Level", subject: "Physics", board: "OCR", title: "OCR A Level Physics (A) (H156/H556)", url: "https://www.ocr.org.uk/qualifications/as-and-a-level/physics-a-h156-h556-from-2015/" },
-  { level: "GCSE", subject: "Biology", board: "OCR", title: "OCR GCSE Biology A (J247)", url: "https://www.ocr.org.uk/qualifications/gcse/biology-a-j247-from-2016/" },
-  { level: "GCSE", subject: "Chemistry", board: "OCR", title: "OCR GCSE Chemistry A (J248)", url: "https://www.ocr.org.uk/qualifications/gcse/chemistry-a-j248-from-2016/" },
-  { level: "GCSE", subject: "English Language", board: "OCR", title: "OCR GCSE English Language (J351)", url: "https://www.ocr.org.uk/qualifications/gcse/english-language-j351-from-2015/" },
+  // OCR — assessment pages hold past papers
+  { level: "GCSE", subject: "Mathematics", board: "OCR", title: "OCR GCSE Maths — Past papers, mark schemes, reports", url: "https://www.ocr.org.uk/qualifications/gcse/mathematics-j560-from-2015/assessment/" },
+  { level: "A Level", subject: "Mathematics", board: "OCR", title: "OCR A Level Maths — Past papers, mark schemes, reports", url: "https://www.ocr.org.uk/qualifications/as-and-a-level/mathematics-a-h230-h240-from-2017/assessment/" },
+  { level: "A Level", subject: "Physics", board: "OCR", title: "OCR A Level Physics — Past papers, mark schemes, reports", url: "https://www.ocr.org.uk/qualifications/as-and-a-level/physics-a-h156-h556-from-2015/assessment/" },
+  { level: "GCSE", subject: "Biology", board: "OCR", title: "OCR GCSE Biology A — Past papers, mark schemes, reports", url: "https://www.ocr.org.uk/qualifications/gcse/biology-a-j247-from-2016/assessment/" },
+  { level: "GCSE", subject: "Chemistry", board: "OCR", title: "OCR GCSE Chemistry A — Past papers, mark schemes, reports", url: "https://www.ocr.org.uk/qualifications/gcse/chemistry-a-j248-from-2016/assessment/" },
+  { level: "GCSE", subject: "English Language", board: "OCR", title: "OCR GCSE English Language — Past papers, mark schemes, reports", url: "https://www.ocr.org.uk/qualifications/gcse/english-language-j351-from-2015/assessment/" },
 
   // WJEC / Eduqas
-  { level: "GCSE", subject: "Mathematics", board: "WJEC", title: "WJEC GCSE Mathematics", url: "https://qualifications.wjec.org.uk/qualifications/mathematics-gcse/" },
-  { level: "A Level", subject: "Biology", board: "Eduqas", title: "Eduqas AS/A Level Biology", url: "https://www.eduqas.co.uk/qualifications/biology-as-a-level/" },
-  { level: "A Level", subject: "Chemistry", board: "Eduqas", title: "Eduqas AS/A Level Chemistry", url: "https://www.eduqas.co.uk/qualifications/chemistry-as-a-level/" },
-  { level: "GCSE", subject: "English Language", board: "Eduqas", title: "Eduqas GCSE English Language", url: "https://www.eduqas.co.uk/qualifications/english-language-gcse/" },
+  { level: "GCSE", subject: "Mathematics", board: "WJEC", title: "WJEC GCSE Maths — Past papers", url: "https://qualifications.wjec.org.uk/qualifications/mathematics-gcse/assessment/" },
+  { level: "A Level", subject: "Biology", board: "Eduqas", title: "Eduqas AS/A Level Biology — Past papers", url: "https://www.eduqas.co.uk/qualifications/biology-as-a-level/#tab_assessmentresources" },
+  { level: "A Level", subject: "Chemistry", board: "Eduqas", title: "Eduqas AS/A Level Chemistry — Past papers", url: "https://www.eduqas.co.uk/qualifications/chemistry-as-a-level/#tab_assessmentresources" },
+  { level: "GCSE", subject: "English Language", board: "Eduqas", title: "Eduqas GCSE English Language — Past papers", url: "https://www.eduqas.co.uk/qualifications/english-language-gcse/#tab_assessmentresources" },
+];
+
+function expandPastPapers() {
+  const entries = [];
+  for (const base of PAST_BASES) {
+    for (const y of YEARS) {
+      if (y === "All") continue;
+      entries.push({ ...base, title: `${base.title} — ${y}`, type: "past_paper", year: y });
+    }
+    // Also include a catch-all entry without year for users who didn't pick a year
+    entries.push({ ...base, type: "past_paper", year: null });
+  }
+  return entries;
+}
+
+const RESOURCE_DATA = [
+  ...SPEC_LINKS,
+  ...expandPastPapers(),
 ];
 
 export default function Resources() {
   const [level, setLevel] = useState("All");
   const [subject, setSubject] = useState("All");
   const [board, setBoard] = useState("All");
+  const [type, setType] = useState("all");
+  const [year, setYear] = useState("All");
 
   const filtered = useMemo(() => {
     return RESOURCE_DATA.filter((r) =>
       (level === "All" || r.level === level) &&
       (subject === "All" || r.subject === subject) &&
-      (board === "All" || r.board === board)
+      (board === "All" || r.board === board) &&
+      (type === "all" || r.type === type) &&
+      (type !== "past_paper" || year === "All" || r.year === year)
     );
-  }, [level, subject, board]);
+  }, [level, subject, board, type, year]);
 
   return (
     <div className="min-h-screen mt-20 p-6" style={{ backgroundColor: "var(--app-bg)" }}>
       <div className="max-w-7xl mx-auto">
         <div className="mb-8">
           <h1 className="text-3xl font-bold mb-2" style={{ color: "var(--nav-to)" }}>Resources</h1>
-          <p className="text-gray-600">Find syllabus pages, past papers, specifications and official guidance from UK exam boards. Filter by level, subject and board.</p>
+          <p className="text-gray-600">Find syllabus pages, past papers, specifications and official guidance from UK exam boards. Filter by level, subject, board, type, and year.</p>
         </div>
 
         {/* Filters */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+        <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-8">
           <div className="flex flex-col">
             <label className="text-sm mb-1 text-gray-700">Level</label>
-            <select
-              value={level}
-              onChange={(e) => setLevel(e.target.value)}
-              className="rounded-lg border px-3 py-2 bg-white"
-            >
+            <select value={level} onChange={(e) => setLevel(e.target.value)} className="rounded-lg border px-3 py-2 bg-white">
               <option>All</option>
-              {LEVELS.map((l) => (
-                <option key={l} value={l}>{l}</option>
-              ))}
+              {LEVELS.map((l) => (<option key={l} value={l}>{l}</option>))}
             </select>
           </div>
           <div className="flex flex-col">
             <label className="text-sm mb-1 text-gray-700">Subject</label>
-            <select
-              value={subject}
-              onChange={(e) => setSubject(e.target.value)}
-              className="rounded-lg border px-3 py-2 bg-white"
-            >
+            <select value={subject} onChange={(e) => setSubject(e.target.value)} className="rounded-lg border px-3 py-2 bg-white">
               <option>All</option>
-              {SUBJECTS.map((s) => (
-                <option key={s} value={s}>{s}</option>
-              ))}
+              {SUBJECTS.map((s) => (<option key={s} value={s}>{s}</option>))}
             </select>
           </div>
           <div className="flex flex-col">
             <label className="text-sm mb-1 text-gray-700">Exam Board</label>
-            <select
-              value={board}
-              onChange={(e) => setBoard(e.target.value)}
-              className="rounded-lg border px-3 py-2 bg-white"
-            >
+            <select value={board} onChange={(e) => setBoard(e.target.value)} className="rounded-lg border px-3 py-2 bg-white">
               <option>All</option>
-              {BOARDS.map((b) => (
-                <option key={b} value={b}>{b}</option>
-              ))}
+              {BOARDS.map((b) => (<option key={b} value={b}>{b}</option>))}
+            </select>
+          </div>
+          <div className="flex flex-col">
+            <label className="text-sm mb-1 text-gray-700">Type</label>
+            <select value={type} onChange={(e) => setType(e.target.value)} className="rounded-lg border px-3 py-2 bg-white">
+              {TYPES.map((t) => (<option key={t.key} value={t.key}>{t.label}</option>))}
+            </select>
+          </div>
+          <div className="flex flex-col">
+            <label className="text-sm mb-1 text-gray-700">Year (past papers)</label>
+            <select value={year} onChange={(e) => setYear(e.target.value === "All" ? "All" : parseInt(e.target.value))} className="rounded-lg border px-3 py-2 bg-white">
+              {YEARS.map((y) => (<option key={y} value={y}>{y}</option>))}
             </select>
           </div>
         </div>
@@ -111,14 +167,16 @@ export default function Resources() {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {filtered.map((r) => (
             <a
-              key={`${r.board}-${r.level}-${r.subject}-${r.url}`}
+              key={`${r.board}-${r.level}-${r.subject}-${r.type}-${r.year ?? "any"}-${r.url}`}
               href={r.url}
               target="_blank"
               rel="noopener noreferrer"
               className="rounded-2xl p-4 border hover:shadow transition bg-white flex flex-col"
               style={{ borderColor: "#e5e7eb" }}
             >
-              <div className="text-xs font-semibold mb-1 text-gray-500">{r.level} • {r.subject} • {r.board}</div>
+              <div className="text-xs font-semibold mb-1 text-gray-500">
+                {r.level} • {r.subject} • {r.board} ��� {r.type === "past_paper" ? `Past papers${r.year ? ` • ${r.year}` : ""}` : "Specification"}
+              </div>
               <div className="text-lg font-semibold mb-2" style={{ color: "var(--primary)" }}>{r.title}</div>
               <div className="mt-auto text-sm text-blue-600">Open official page →</div>
             </a>

--- a/src/pages/Resources.jsx
+++ b/src/pages/Resources.jsx
@@ -20,42 +20,42 @@ const YEARS = ["All", 2024, 2023, 2022, 2021, 2020, 2019, 2018];
 // Replace unicode dashes/bullets that might render as replacement chars on some systems
 function sanitize(text) {
   return String(text)
-    .replace(/\u2014|\u2013|\u2212|\u2043/g, "-") // various dashes to hyphen
-    .replace(/\u2022/g, "-") // bullet to hyphen
+    .replace(/\u2014|\u2013|\u2212|\u2043/g, "-")
+    .replace(/\u2022/g, "-")
     .replace(/\s+-\s+/g, " - ");
 }
 
 // Specification pages (official exam board specs)
 const SPEC_LINKS = [
   // AQA (specifications)
-  { level: "GCSE", subject: "Mathematics", board: "AQA", title: "AQA GCSE Maths (8300) — Specification", url: "https://www.aqa.org.uk/subjects/mathematics/gcse/mathematics-8300/specification-at-a-glance", type: "specification" },
-  { level: "A Level", subject: "Mathematics", board: "AQA", title: "AQA A-level Maths (7357) — Specification", url: "https://www.aqa.org.uk/subjects/mathematics/as-and-a-level/mathematics-7357/specification-at-a-glance", type: "specification" },
-  { level: "GCSE", subject: "English Language", board: "AQA", title: "AQA GCSE English Language (8700) — Specification", url: "https://www.aqa.org.uk/subjects/english/gcse/english-language-8700/specification-at-a-glance", type: "specification" },
-  { level: "A Level", subject: "Physics", board: "AQA", title: "AQA A-level Physics (7408) — Specification", url: "https://www.aqa.org.uk/subjects/science/as-and-a-level/physics-7408/specification-at-a-glance", type: "specification" },
-  { level: "GCSE", subject: "Biology", board: "AQA", title: "AQA GCSE Biology (8461) — Specification", url: "https://www.aqa.org.uk/subjects/science/gcse/biology-8461/specification-at-a-glance", type: "specification" },
-  { level: "GCSE", subject: "Chemistry", board: "AQA", title: "AQA GCSE Chemistry (8462) — Specification", url: "https://www.aqa.org.uk/subjects/science/gcse/chemistry-8462/specification-at-a-glance", type: "specification" },
+  { level: "GCSE", subject: "Mathematics", board: "AQA", title: "AQA GCSE Maths - Specification", url: "https://www.aqa.org.uk/subjects/mathematics/gcse/mathematics-8300/specification-at-a-glance", type: "specification" },
+  { level: "A Level", subject: "Mathematics", board: "AQA", title: "AQA A-level Maths (7357) - Specification", url: "https://www.aqa.org.uk/subjects/mathematics/as-and-a-level/mathematics-7357/specification-at-a-glance", type: "specification" },
+  { level: "GCSE", subject: "English Language", board: "AQA", title: "AQA GCSE English Language (8700) - Specification", url: "https://www.aqa.org.uk/subjects/english/gcse/english-language-8700/specification-at-a-glance", type: "specification" },
+  { level: "A Level", subject: "Physics", board: "AQA", title: "AQA A-level Physics (7408) - Specification", url: "https://www.aqa.org.uk/subjects/science/as-and-a-level/physics-7408/specification-at-a-glance", type: "specification" },
+  { level: "GCSE", subject: "Biology", board: "AQA", title: "AQA GCSE Biology (8461) - Specification", url: "https://www.aqa.org.uk/subjects/science/gcse/biology-8461/specification-at-a-glance", type: "specification" },
+  { level: "GCSE", subject: "Chemistry", board: "AQA", title: "AQA GCSE Chemistry (8462) - Specification", url: "https://www.aqa.org.uk/subjects/science/gcse/chemistry-8462/specification-at-a-glance", type: "specification" },
 
   // Pearson Edexcel (specifications)
-  { level: "GCSE", subject: "Mathematics", board: "Edexcel", title: "Edexcel GCSE Maths (9-1) — Specification", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/mathematics-2015.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FTeaching-and-learning-materials", type: "specification" },
-  { level: "A Level", subject: "Mathematics", board: "Edexcel", title: "Edexcel A level Maths — Specification", url: "https://qualifications.pearson.com/en/qualifications/edexcel-a-levels/mathematics-2017.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FTeaching-and-learning-materials", type: "specification" },
-  { level: "A Level", subject: "Physics", board: "Edexcel", title: "Edexcel A level Physics — Specification", url: "https://qualifications.pearson.com/en/qualifications/edexcel-a-levels/physics-2015.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FTeaching-and-learning-materials", type: "specification" },
-  { level: "GCSE", subject: "Biology", board: "Edexcel", title: "Edexcel GCSE Biology — Specification", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/biology-2016.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FTeaching-and-learning-materials", type: "specification" },
-  { level: "GCSE", subject: "Chemistry", board: "Edexcel", title: "Edexcel GCSE Chemistry — Specification", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/chemistry-2016.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FTeaching-and-learning-materials", type: "specification" },
-  { level: "GCSE", subject: "English Language", board: "Edexcel", title: "Edexcel GCSE English Language — Specification", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/english-language-2015.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FTeaching-and-learning-materials", type: "specification" },
+  { level: "GCSE", subject: "Mathematics", board: "Edexcel", title: "Edexcel GCSE Maths (9-1) - Specification", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/mathematics-2015.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FTeaching-and-learning-materials", type: "specification" },
+  { level: "A Level", subject: "Mathematics", board: "Edexcel", title: "Edexcel A level Maths - Specification", url: "https://qualifications.pearson.com/en/qualifications/edexcel-a-levels/mathematics-2017.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FTeaching-and-learning-materials", type: "specification" },
+  { level: "A Level", subject: "Physics", board: "Edexcel", title: "Edexcel A level Physics - Specification", url: "https://qualifications.pearson.com/en/qualifications/edexcel-a-levels/physics-2015.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FTeaching-and-learning-materials", type: "specification" },
+  { level: "GCSE", subject: "Biology", board: "Edexcel", title: "Edexcel GCSE Biology - Specification", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/biology-2016.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FTeaching-and-learning-materials", type: "specification" },
+  { level: "GCSE", subject: "Chemistry", board: "Edexcel", title: "Edexcel GCSE Chemistry - Specification", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/chemistry-2016.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FTeaching-and-learning-materials", type: "specification" },
+  { level: "GCSE", subject: "English Language", board: "Edexcel", title: "Edexcel GCSE English Language - Specification", url: "https://qualifications.pearson.com/en/qualifications/edexcel-gcses/english-language-2015.coursematerials.html#filterQuery=category:Pearson-UK:Category%2FTeaching-and-learning-materials", type: "specification" },
 
   // OCR (specifications)
-  { level: "GCSE", subject: "Mathematics", board: "OCR", title: "OCR GCSE Maths (J560) — Specification", url: "https://www.ocr.org.uk/qualifications/gcse/mathematics-j560-from-2015/specification-at-a-glance/", type: "specification" },
-  { level: "A Level", subject: "Mathematics", board: "OCR", title: "OCR A Level Maths (A) — Specification", url: "https://www.ocr.org.uk/qualifications/as-and-a-level/mathematics-a-h230-h240-from-2017/specification-at-a-glance/", type: "specification" },
-  { level: "A Level", subject: "Physics", board: "OCR", title: "OCR A Level Physics (A) — Specification", url: "https://www.ocr.org.uk/qualifications/as-and-a-level/physics-a-h156-h556-from-2015/specification-at-a-glance/", type: "specification" },
-  { level: "GCSE", subject: "Biology", board: "OCR", title: "OCR GCSE Biology A (J247) — Specification", url: "https://www.ocr.org.uk/qualifications/gcse/biology-a-j247-from-2016/specification-at-a-glance/", type: "specification" },
-  { level: "GCSE", subject: "Chemistry", board: "OCR", title: "OCR GCSE Chemistry A (J248) — Specification", url: "https://www.ocr.org.uk/qualifications/gcse/chemistry-a-j248-from-2016/specification-at-a-glance/", type: "specification" },
-  { level: "GCSE", subject: "English Language", board: "OCR", title: "OCR GCSE English Language (J351) — Specification", url: "https://www.ocr.org.uk/qualifications/gcse/english-language-j351-from-2015/specification-at-a-glance/", type: "specification" },
+  { level: "GCSE", subject: "Mathematics", board: "OCR", title: "OCR GCSE Maths (J560) - Specification", url: "https://www.ocr.org.uk/qualifications/gcse/mathematics-j560-from-2015/specification-at-a-glance/", type: "specification" },
+  { level: "A Level", subject: "Mathematics", board: "OCR", title: "OCR A Level Maths (A) - Specification", url: "https://www.ocr.org.uk/qualifications/as-and-a-level/mathematics-a-h230-h240-from-2017/specification-at-a-glance/", type: "specification" },
+  { level: "A Level", subject: "Physics", board: "OCR", title: "OCR A Level Physics (A) - Specification", url: "https://www.ocr.org.uk/qualifications/as-and-a-level/physics-a-h156-h556-from-2015/specification-at-a-glance/", type: "specification" },
+  { level: "GCSE", subject: "Biology", board: "OCR", title: "OCR GCSE Biology A (J247) - Specification", url: "https://www.ocr.org.uk/qualifications/gcse/biology-a-j247-from-2016/specification-at-a-glance/", type: "specification" },
+  { level: "GCSE", subject: "Chemistry", board: "OCR", title: "OCR GCSE Chemistry A (J248) - Specification", url: "https://www.ocr.org.uk/qualifications/gcse/chemistry-a-j248-from-2016/specification-at-a-glance/", type: "specification" },
+  { level: "GCSE", subject: "English Language", board: "OCR", title: "OCR GCSE English Language (J351) - Specification", url: "https://www.ocr.org.uk/qualifications/gcse/english-language-j351-from-2015/specification-at-a-glance/", type: "specification" },
 
   // WJEC / Eduqas (specifications)
-  { level: "GCSE", subject: "Mathematics", board: "WJEC", title: "WJEC GCSE Mathematics — Specification", url: "https://qualifications.wjec.org.uk/qualifications/mathematics-gcse/", type: "specification" },
-  { level: "A Level", subject: "Biology", board: "Eduqas", title: "Eduqas AS/A Level Biology — Specification", url: "https://www.eduqas.co.uk/qualifications/biology-as-a-level/", type: "specification" },
-  { level: "A Level", subject: "Chemistry", board: "Eduqas", title: "Eduqas AS/A Level Chemistry — Specification", url: "https://www.eduqas.co.uk/qualifications/chemistry-as-a-level/", type: "specification" },
-  { level: "GCSE", subject: "English Language", board: "Eduqas", title: "Eduqas GCSE English Language — Specification", url: "https://www.eduqas.co.uk/qualifications/english-language-gcse/", type: "specification" },
+  { level: "GCSE", subject: "Mathematics", board: "WJEC", title: "WJEC GCSE Mathematics - Specification", url: "https://qualifications.wjec.org.uk/qualifications/mathematics-gcse/", type: "specification" },
+  { level: "A Level", subject: "Biology", board: "Eduqas", title: "Eduqas AS/A Level Biology - Specification", url: "https://www.eduqas.co.uk/qualifications/biology-as-a-level/", type: "specification" },
+  { level: "A Level", subject: "Chemistry", board: "Eduqas", title: "Eduqas AS/A Level Chemistry - Specification", url: "https://www.eduqas.co.uk/qualifications/chemistry-as-a-level/", type: "specification" },
+  { level: "GCSE", subject: "English Language", board: "Eduqas", title: "Eduqas GCSE English Language - Specification", url: "https://www.eduqas.co.uk/qualifications/english-language-gcse/", type: "specification" },
 ];
 
 // Past paper hubs (official board pages that contain all years/series)
@@ -127,13 +127,15 @@ export default function Resources() {
     );
   }, [level, subject, board, type, year]);
 
+  const selectCls = "rounded-lg border px-3 py-2 bg-white/10 text-white border-white/20";
+
   return (
-    <div className="min-h-screen mt-20 p-6" style={{ backgroundColor: "var(--app-bg)" }}>
+    <div className="min-h-screen mt-20 p-6 hero-gradient text-white">
       <div className="max-w-7xl mx-auto">
         <div className="mb-8 flex items-start justify-between gap-4 flex-wrap">
           <div>
-            <h1 className="text-3xl font-bold mb-2" style={{ color: "var(--nav-to)" }}>Resources</h1>
-            <p className="text-gray-600">Find syllabus pages, past papers, specifications and official guidance from UK exam boards. Filter by level, subject, board, type, and year.</p>
+            <h1 className="text-3xl font-bold mb-2">Resources</h1>
+            <p className="text-white/80">Find syllabus pages, past papers, specifications and official guidance from UK exam boards. Filter by level, subject, board, type, and year.</p>
           </div>
           {/* View toggle */}
           <div className="flex items-center gap-2">
@@ -141,7 +143,7 @@ export default function Resources() {
               type="button"
               aria-pressed={view === "grid"}
               onClick={() => setView("grid")}
-              className={`px-3 py-2 rounded-lg border text-sm ${view === "grid" ? "bg-[var(--primary)] text-white border-transparent" : "bg-white text-gray-700 border-gray-200"}`}
+              className={`px-3 py-2 rounded-lg border text-sm ${view === "grid" ? "bg-white/20 text-white border-white/0" : "bg-white/10 text-white border-white/20"}`}
             >
               Grid
             </button>
@@ -149,7 +151,7 @@ export default function Resources() {
               type="button"
               aria-pressed={view === "list"}
               onClick={() => setView("list")}
-              className={`px-3 py-2 rounded-lg border text-sm ${view === "list" ? "bg-[var(--primary)] text-white border-transparent" : "bg-white text-gray-700 border-gray-200"}`}
+              className={`px-3 py-2 rounded-lg border text-sm ${view === "list" ? "bg-white/20 text-white border-white/0" : "bg-white/10 text-white border-white/20"}`}
             >
               List
             </button>
@@ -159,35 +161,35 @@ export default function Resources() {
         {/* Filters */}
         <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-8">
           <div className="flex flex-col">
-            <label className="text-sm mb-1 text-gray-700">Level</label>
-            <select value={level} onChange={(e) => setLevel(e.target.value)} className="rounded-lg border px-3 py-2 bg-white">
+            <label className="text-sm mb-1 text-white/80">Level</label>
+            <select value={level} onChange={(e) => setLevel(e.target.value)} className={selectCls}>
               <option>All</option>
               {LEVELS.map((l) => (<option key={l} value={l}>{l}</option>))}
             </select>
           </div>
           <div className="flex flex-col">
-            <label className="text-sm mb-1 text-gray-700">Subject</label>
-            <select value={subject} onChange={(e) => setSubject(e.target.value)} className="rounded-lg border px-3 py-2 bg-white">
+            <label className="text-sm mb-1 text-white/80">Subject</label>
+            <select value={subject} onChange={(e) => setSubject(e.target.value)} className={selectCls}>
               <option>All</option>
               {SUBJECTS.map((s) => (<option key={s} value={s}>{s}</option>))}
             </select>
           </div>
           <div className="flex flex-col">
-            <label className="text-sm mb-1 text-gray-700">Exam Board</label>
-            <select value={board} onChange={(e) => setBoard(e.target.value)} className="rounded-lg border px-3 py-2 bg-white">
+            <label className="text-sm mb-1 text-white/80">Exam Board</label>
+            <select value={board} onChange={(e) => setBoard(e.target.value)} className={selectCls}>
               <option>All</option>
               {BOARDS.map((b) => (<option key={b} value={b}>{b}</option>))}
             </select>
           </div>
           <div className="flex flex-col">
-            <label className="text-sm mb-1 text-gray-700">Type</label>
-            <select value={type} onChange={(e) => setType(e.target.value)} className="rounded-lg border px-3 py-2 bg-white">
+            <label className="text-sm mb-1 text-white/80">Type</label>
+            <select value={type} onChange={(e) => setType(e.target.value)} className={selectCls}>
               {TYPES.map((t) => (<option key={t.key} value={t.key}>{t.label}</option>))}
             </select>
           </div>
           <div className="flex flex-col">
-            <label className="text-sm mb-1 text-gray-700">Year (past papers)</label>
-            <select value={year} onChange={(e) => setYear(e.target.value === "All" ? "All" : parseInt(e.target.value))} className="rounded-lg border px-3 py-2 bg-white">
+            <label className="text-sm mb-1 text-white/80">Year (past papers)</label>
+            <select value={year} onChange={(e) => setYear(e.target.value === "All" ? "All" : parseInt(e.target.value))} className={selectCls}>
               {YEARS.map((y) => (<option key={y} value={y}>{y}</option>))}
             </select>
           </div>
@@ -202,28 +204,28 @@ export default function Resources() {
                 href={r.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="rounded-2xl p-4 border hover:shadow transition bg-white flex flex-col"
-                style={{ borderColor: "#e5e7eb" }}
+                className="rounded-2xl p-4 border hover:shadow transition bg-white/10 flex flex-col"
+                style={{ borderColor: "rgba(255,255,255,0.2)" }}
               >
-                <div className="text-xs font-semibold mb-1 text-gray-500">
+                <div className="text-xs font-semibold mb-1 text-white/70">
                   {sanitize(r.level)} - {sanitize(r.subject)} - {sanitize(r.board)} - {r.type === "past_paper" ? `Past papers${r.year ? ` - ${r.year}` : ""}` : "Specification"}
                 </div>
-                <div className="text-lg font-semibold mb-2" style={{ color: "var(--primary)" }}>{sanitize(r.title)}</div>
-                <div className="mt-auto text-sm text-blue-600">Open official page →</div>
+                <div className="text-lg font-semibold mb-2" style={{ color: "var(--on-primary)" }}>{sanitize(r.title)}</div>
+                <div className="mt-auto text-sm text-blue-200">Open official page →</div>
               </a>
             ))}
           </div>
         ) : (
-          <div className="bg-white rounded-2xl border" style={{ borderColor: "#e5e7eb" }}>
-            <ul className="divide-y" style={{ borderColor: "#e5e7eb" }}>
+          <div className="bg-white/10 rounded-2xl border" style={{ borderColor: "rgba(255,255,255,0.2)" }}>
+            <ul className="divide-y" style={{ borderColor: "rgba(255,255,255,0.2)" }}>
               {filtered.map((r) => (
-                <li key={`${r.board}-${r.level}-${r.subject}-${r.type}-${r.year ?? "any"}-${r.url}`} className="p-4 hover:bg-gray-50 transition">
+                <li key={`${r.board}-${r.level}-${r.subject}-${r.type}-${r.year ?? "any"}-${r.url}`} className="p-4 hover:bg-white/10 transition">
                   <a href={r.url} target="_blank" rel="noopener noreferrer" className="flex flex-col sm:flex-row sm:items-center gap-2">
-                    <span className="text-sm text-gray-500 flex-1">
+                    <span className="text-sm text-white/70 flex-1">
                       {sanitize(r.level)} - {sanitize(r.subject)} - {sanitize(r.board)} - {r.type === "past_paper" ? `Past papers${r.year ? ` - ${r.year}` : ""}` : "Specification"}
                     </span>
-                    <span className="font-semibold" style={{ color: "var(--primary)" }}>{sanitize(r.title)}</span>
-                    <span className="text-blue-600 text-sm">Open →</span>
+                    <span className="font-semibold" style={{ color: "var(--on-primary)" }}>{sanitize(r.title)}</span>
+                    <span className="text-blue-200 text-sm">Open →</span>
                   </a>
                 </li>
               ))}
@@ -232,7 +234,7 @@ export default function Resources() {
         )}
 
         {filtered.length === 0 && (
-          <div className="text-gray-500 text-center py-16">No resources found. Try different filters.</div>
+          <div className="text-white/70 text-center py-16">No resources found. Try different filters.</div>
         )}
       </div>
     </div>

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = "1.05";
+export const APP_VERSION = "1.06";


### PR DESCRIPTION
## Purpose

The user requested a comprehensive Resources page to help students access exam board materials more efficiently. They wanted filtering capabilities by level (GCSE, A Level), subject, and exam board, with links to official past papers and specifications. Additionally, they requested UI improvements including grid/list view toggle, dark mode theming, and updated XP calculation formula for the gamification system.

## Code changes

- **New Resources page**: Created `/src/pages/Resources.jsx` with filtering system for level, subject, exam board, type (past papers/specifications), and year
- **Navigation updates**: Added Resources link to sidebar, navbar, and footer with proper routing
- **Theme integration**: Wrapped app in ThemeProvider and applied dark mode styling to Resources page
- **XP formula change**: Updated gamification system from `50 × Level^1.5` to `10 × Level^1.2` 
- **UI enhancements**: Added grid/list view toggle and sanitized text display to remove unicode characters
- **Version bump**: Updated app version from 1.05 to 1.06

The Resources page includes comprehensive links to official exam board websites (AQA, Edexcel, OCR, WJEC, Eduqas) for specifications and past papers across multiple subjects and years.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8b938d3cb92c4ba78c137c133ee459cd/nova-garden)

👀 [Preview Link](https://8b938d3cb92c4ba78c137c133ee459cd-nova-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8b938d3cb92c4ba78c137c133ee459cd</projectId>-->
<!--<branchName>nova-garden</branchName>-->