### PR TITLE
Feat: Implement dashboard view toggle and enhance cards

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -68,8 +68,8 @@
   gtag('config', 'G-DCM1WBN2ZQ');
 </script>
 
-    <script type="module" crossorigin src="/assets/index-811aa1c8.js"></script>
-    <link rel="stylesheet" href="/assets/index-0b050793.css">
+    <script type="module" crossorigin src="/assets/index-37f953bc.js"></script>
+    <link rel="stylesheet" href="/assets/index-9e51edcd.css">
   </head>
   <body>
     <div id="root"></div>

--- a/dist/index.html
+++ b/dist/index.html
@@ -68,8 +68,8 @@
   gtag('config', 'G-DCM1WBN2ZQ');
 </script>
 
-    <script type="module" crossorigin src="/assets/index-aeb343ef.js"></script>
-    <link rel="stylesheet" href="/assets/index-52569c67.css">
+    <script type="module" crossorigin src="/assets/index-fae83707.js"></script>
+    <link rel="stylesheet" href="/assets/index-71ec4d6b.css">
   </head>
   <body>
     <div id="root"></div>

--- a/dist/index.html
+++ b/dist/index.html
@@ -68,8 +68,8 @@
   gtag('config', 'G-DCM1WBN2ZQ');
 </script>
 
-    <script type="module" crossorigin src="/assets/index-fae83707.js"></script>
-    <link rel="stylesheet" href="/assets/index-71ec4d6b.css">
+    <script type="module" crossorigin src="/assets/index-811aa1c8.js"></script>
+    <link rel="stylesheet" href="/assets/index-0b050793.css">
   </head>
   <body>
     <div id="root"></div>

--- a/node_modules/.vite/deps/_metadata.json
+++ b/node_modules/.vite/deps/_metadata.json
@@ -1,59 +1,59 @@
 {
-  "hash": "4ed15acf",
-  "browserHash": "569f3d87",
+  "hash": "afa5cfdc",
+  "browserHash": "b80c9bed",
   "optimized": {
     "react": {
       "src": "../../react/index.js",
       "file": "react.js",
-      "fileHash": "47360648",
+      "fileHash": "0715b88c",
       "needsInterop": true
     },
     "react-dom": {
       "src": "../../react-dom/index.js",
       "file": "react-dom.js",
-      "fileHash": "a4c32814",
+      "fileHash": "fa37ed6b",
       "needsInterop": true
     },
     "react/jsx-dev-runtime": {
       "src": "../../react/jsx-dev-runtime.js",
       "file": "react_jsx-dev-runtime.js",
-      "fileHash": "3e7c6d6f",
+      "fileHash": "6ee7c076",
       "needsInterop": true
     },
     "react/jsx-runtime": {
       "src": "../../react/jsx-runtime.js",
       "file": "react_jsx-runtime.js",
-      "fileHash": "3017aabf",
+      "fileHash": "ff1dc2f4",
       "needsInterop": true
     },
     "@supabase/supabase-js": {
       "src": "../../@supabase/supabase-js/dist/module/index.js",
       "file": "@supabase_supabase-js.js",
-      "fileHash": "508f32c6",
+      "fileHash": "f45ea510",
       "needsInterop": false
     },
     "framer-motion": {
       "src": "../../framer-motion/dist/es/index.mjs",
       "file": "framer-motion.js",
-      "fileHash": "36487970",
+      "fileHash": "ebce2128",
       "needsInterop": false
     },
     "lucide-react": {
       "src": "../../lucide-react/dist/esm/lucide-react.js",
       "file": "lucide-react.js",
-      "fileHash": "9483e839",
+      "fileHash": "c9e78ae7",
       "needsInterop": false
     },
     "react-dom/client": {
       "src": "../../react-dom/client.js",
       "file": "react-dom_client.js",
-      "fileHash": "26f92954",
+      "fileHash": "e70623a5",
       "needsInterop": true
     },
     "react-router-dom": {
       "src": "../../react-router-dom/dist/index.mjs",
       "file": "react-router-dom.js",
-      "fileHash": "606622ae",
+      "fileHash": "5e13e8b7",
       "needsInterop": false
     }
   },
@@ -64,11 +64,11 @@
     "chunk-QH3POG6S": {
       "file": "chunk-QH3POG6S.js"
     },
-    "chunk-VZBRM2AZ": {
-      "file": "chunk-VZBRM2AZ.js"
-    },
     "chunk-G52XTN3B": {
       "file": "chunk-G52XTN3B.js"
+    },
+    "chunk-VZBRM2AZ": {
+      "file": "chunk-VZBRM2AZ.js"
     },
     "chunk-LXGCQ6UQ": {
       "file": "chunk-LXGCQ6UQ.js"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -203,7 +203,6 @@ function App() {
 }
 
 function DashboardToggle() {
-  const { useDashboard } = require('./context/DashboardContext');
   const { showGamified } = useDashboard();
 
   return showGamified ? <GamifiedDashboard /> : <Dashboard />;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,7 +22,7 @@ import Signup from './pages/Signup';
 import OnboardingModal from "./components/OnboardingModal";
 import Footer from './components/Footer';
 import { ThemeProvider } from './context/ThemeContext';
-import { DashboardProvider } from './context/DashboardContext';
+import { DashboardProvider, useDashboard } from './context/DashboardContext';
 import './styles/index.css';
 
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,9 +44,10 @@ function App() {
       <GamificationProvider>
         <TimerProvider>
           <ThemeProvider>
-            <Router>
-              <RouteCleanup />
-            <Routes>
+            <DashboardProvider>
+              <Router>
+                <RouteCleanup />
+              <Routes>
               {/* Public Routes */}
               <Route path="/" element={<div className="flex flex-col min-h-screen"><main className="flex-1"><Landing /><Footer /></main></div>} />
               <Route path="/login" element={<div className="flex flex-col min-h-screen"><main className="flex-1"><Login /><Footer /></main></div>} />
@@ -64,7 +65,7 @@ function App() {
                     <div className="flex-1 flex flex-col">
                       <Navbar />
                       <main className="flex-1 overflow-auto">
-                        <GamifiedDashboard />
+                        <DashboardToggle />
                         <Footer withSidebar />
                       </main>
                     </div>
@@ -192,12 +193,20 @@ function App() {
                 </ProtectedRoute>
               } />
             </Routes>
-          </Router>
+              </Router>
+            </DashboardProvider>
           </ThemeProvider>
         </TimerProvider>
       </GamificationProvider>
     </AuthProvider>
   );
+}
+
+function DashboardToggle() {
+  const { useDashboard } = require('./context/DashboardContext');
+  const { showGamified } = useDashboard();
+
+  return showGamified ? <GamifiedDashboard /> : <Dashboard />;
 }
 
 export default App;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import Signup from './pages/Signup';
 import OnboardingModal from "./components/OnboardingModal";
 import Footer from './components/Footer';
 import { ThemeProvider } from './context/ThemeContext';
+import { DashboardProvider } from './context/DashboardContext';
 import './styles/index.css';
 
 

--- a/src/components/DashboardViewToggle.jsx
+++ b/src/components/DashboardViewToggle.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useDashboard } from '../context/DashboardContext';
+
+export default function DashboardViewToggle() {
+  const { showGamified, toggleDashboard } = useDashboard();
+
+  return (
+    <div className="inline-flex rounded-lg border border-white/20 backdrop-blur bg-white/5 p-1">
+      <button
+        onClick={toggleDashboard}
+        className={`px-4 py-2 rounded-md font-semibold text-sm transition-all ${
+          showGamified
+            ? 'bg-gradient-to-r from-cyan-500 to-blue-600 text-white shadow-lg'
+            : 'text-white/70 hover:text-white'
+        }`}
+      >
+        Full View
+      </button>
+      <button
+        onClick={toggleDashboard}
+        className={`px-4 py-2 rounded-md font-semibold text-sm transition-all ${
+          !showGamified
+            ? 'bg-gradient-to-r from-cyan-500 to-blue-600 text-white shadow-lg'
+            : 'text-white/70 hover:text-white'
+        }`}
+      >
+        Basic View
+      </button>
+    </div>
+  );
+}

--- a/src/components/GamifiedDashboard.jsx
+++ b/src/components/GamifiedDashboard.jsx
@@ -26,7 +26,6 @@ import {
 } from "lucide-react";
 import { useGamification } from "../context/GamificationContext";
 import { useAuth } from "../context/AuthContext";
-import { useDashboard } from "../context/DashboardContext";
 import { AnimatedProgressBar } from "./RewardAnimations";
 import StreakTracker from "./StreakTracker";
 import QuestSystem from "./QuestSystem";

--- a/src/components/GamifiedDashboard.jsx
+++ b/src/components/GamifiedDashboard.jsx
@@ -36,6 +36,7 @@ import AchievementSystem from "./AchievementSystem";
 import RewardSystem from "./RewardSystem";
 import MysteryBox from "./MysteryBox";
 import OnboardingModal from "./OnboardingModal";
+import DashboardViewToggle from "./DashboardViewToggle";
 
 const formatHM = (totalMinutes) => {
   const m = Math.max(0, Math.round(totalMinutes || 0));
@@ -219,7 +220,7 @@ const GamifiedDashboard = () => {
                     <ul className="space-y-1 text-purple-700">
                       <li>• Earn gems from studying, quests, or jackpots.</li>
                       <li>• Spend gems on streak savers, boosts, or cosmetic upgrades.</li>
-                      <li>��� Premium users get extra perks + higher rewards.</li>
+                      <li>• Premium users get extra perks + higher rewards.</li>
                     </ul>
                   </div>
                 </div>

--- a/src/components/GamifiedDashboard.jsx
+++ b/src/components/GamifiedDashboard.jsx
@@ -45,6 +45,7 @@ const formatHM = (totalMinutes) => {
 };
 
 const GamifiedDashboard = () => {
+  const navigate = useNavigate();
   const {
     userStats,
     getUserRank,

--- a/src/components/GamifiedDashboard.jsx
+++ b/src/components/GamifiedDashboard.jsx
@@ -322,13 +322,11 @@ const GamifiedDashboard = () => {
 
           {/* Key Stats */}
           <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-            <motion.button
+            <button
               onClick={() => navigate('/insights')}
-              whileHover={{ y: -8 }}
-              transition={{ duration: 0.2 }}
-              className="text-left group cursor-pointer focus:outline-none"
+              className="group relative h-full text-left focus:outline-none"
             >
-              <div className="bg-white/10 rounded-2xl p-4 backdrop-blur group-hover:bg-white/20 transition-all">
+              <div className="bg-white/10 rounded-2xl p-4 backdrop-blur group-hover:bg-white/20 transition-all h-full flex flex-col">
                 <div className="flex items-center gap-3 mb-2">
                   <Flame className="w-6 h-6 text-orange-300" />
                   <span className="font-semibold">Current Streak</span>
@@ -338,22 +336,16 @@ const GamifiedDashboard = () => {
                   {userStats.currentStreak}
                 </div>
               </div>
-              <motion.div
-                initial={{ opacity: 0 }}
-                whileHover={{ opacity: 1 }}
-                className="mt-2 bg-black/40 rounded-lg px-3 py-2 text-white text-sm font-medium text-center"
-              >
-                Click the card for more insights
-              </motion.div>
-            </motion.button>
+              <div className="absolute inset-0 bg-black/30 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                <span className="text-white font-medium text-sm">Click to see more</span>
+              </div>
+            </button>
 
-            <motion.button
+            <button
               onClick={() => navigate('/insights')}
-              whileHover={{ y: -8 }}
-              transition={{ duration: 0.2 }}
-              className="text-left group cursor-pointer focus:outline-none"
+              className="group relative h-full text-left focus:outline-none"
             >
-              <div className="bg-white/10 rounded-2xl p-4 backdrop-blur group-hover:bg-white/20 transition-all">
+              <div className="bg-white/10 rounded-2xl p-4 backdrop-blur group-hover:bg-white/20 transition-all h-full flex flex-col">
                 <div className="flex items-center gap-3 mb-2">
                   <Clock className="w-6 h-6 text-blue-300" />
                   <span className="font-semibold">Study Time</span>
@@ -362,14 +354,10 @@ const GamifiedDashboard = () => {
                   {formatHM(userStats.totalStudyTime)}
                 </div>
               </div>
-              <motion.div
-                initial={{ opacity: 0 }}
-                whileHover={{ opacity: 1 }}
-                className="mt-2 bg-black/40 rounded-lg px-3 py-2 text-white text-sm font-medium text-center"
-              >
-                Click the card for more insights
-              </motion.div>
-            </motion.button>
+              <div className="absolute inset-0 bg-black/30 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                <span className="text-white font-medium text-sm">Click to see more</span>
+              </div>
+            </button>
 
             <div className="bg-white/10 rounded-2xl p-4 backdrop-blur">
               <div className="flex items-center gap-3 mb-2">

--- a/src/components/GamifiedDashboard.jsx
+++ b/src/components/GamifiedDashboard.jsx
@@ -27,6 +27,7 @@ import {
 } from "lucide-react";
 import { useGamification } from "../context/GamificationContext";
 import { useAuth } from "../context/AuthContext";
+import { useDashboard } from "../context/DashboardContext";
 import { AnimatedProgressBar } from "./RewardAnimations";
 import StreakTracker from "./StreakTracker";
 import QuestSystem from "./QuestSystem";

--- a/src/components/GamifiedDashboard.jsx
+++ b/src/components/GamifiedDashboard.jsx
@@ -284,14 +284,8 @@ const GamifiedDashboard = () => {
             </div>
 
             {/* Quick Actions */}
-            <div className="flex items-center gap-3">
-              <button
-                onClick={toggleDashboard}
-                className="p-2 bg-white/20 hover:bg-white/30 rounded-xl transition-all"
-                title="Switch to classic dashboard"
-              >
-                <Maximize2 className="w-5 h-5" />
-              </button>
+            <div className="flex items-center gap-4">
+              <DashboardViewToggle />
               <button
                 onClick={() => setShowSettingsPopup(true)}
                 className="p-2 bg-white/20 hover:bg-white/30 rounded-xl transition-all"

--- a/src/components/GamifiedDashboard.jsx
+++ b/src/components/GamifiedDashboard.jsx
@@ -322,26 +322,54 @@ const GamifiedDashboard = () => {
 
           {/* Key Stats */}
           <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-            <div className="bg-white/10 rounded-2xl p-4 backdrop-blur">
-              <div className="flex items-center gap-3 mb-2">
-                <Flame className="w-6 h-6 text-orange-300" />
-                <span className="font-semibold">Current Streak</span>
+            <motion.button
+              onClick={() => navigate('/insights')}
+              whileHover={{ y: -8 }}
+              transition={{ duration: 0.2 }}
+              className="text-left group cursor-pointer focus:outline-none"
+            >
+              <div className="bg-white/10 rounded-2xl p-4 backdrop-blur group-hover:bg-white/20 transition-all">
+                <div className="flex items-center gap-3 mb-2">
+                  <Flame className="w-6 h-6 text-orange-300" />
+                  <span className="font-semibold">Current Streak</span>
+                </div>
+                <div className="text-2xl font-bold">
+                  {getStreakEmoji(userStats.currentStreak)}{" "}
+                  {userStats.currentStreak}
+                </div>
               </div>
-              <div className="text-2xl font-bold">
-                {getStreakEmoji(userStats.currentStreak)}{" "}
-                {userStats.currentStreak}
-              </div>
-            </div>
+              <motion.div
+                initial={{ opacity: 0 }}
+                whileHover={{ opacity: 1 }}
+                className="mt-2 bg-black/40 rounded-lg px-3 py-2 text-white text-sm font-medium text-center"
+              >
+                Click the card for more insights
+              </motion.div>
+            </motion.button>
 
-            <div className="bg-white/10 rounded-2xl p-4 backdrop-blur">
-              <div className="flex items-center gap-3 mb-2">
-                <Clock className="w-6 h-6 text-blue-300" />
-                <span className="font-semibold">Study Time</span>
+            <motion.button
+              onClick={() => navigate('/insights')}
+              whileHover={{ y: -8 }}
+              transition={{ duration: 0.2 }}
+              className="text-left group cursor-pointer focus:outline-none"
+            >
+              <div className="bg-white/10 rounded-2xl p-4 backdrop-blur group-hover:bg-white/20 transition-all">
+                <div className="flex items-center gap-3 mb-2">
+                  <Clock className="w-6 h-6 text-blue-300" />
+                  <span className="font-semibold">Study Time</span>
+                </div>
+                <div className="text-2xl font-bold">
+                  {formatHM(userStats.totalStudyTime)}
+                </div>
               </div>
-              <div className="text-2xl font-bold">
-                {formatHM(userStats.totalStudyTime)}
-              </div>
-            </div>
+              <motion.div
+                initial={{ opacity: 0 }}
+                whileHover={{ opacity: 1 }}
+                className="mt-2 bg-black/40 rounded-lg px-3 py-2 text-white text-sm font-medium text-center"
+              >
+                Click the card for more insights
+              </motion.div>
+            </motion.button>
 
             <div className="bg-white/10 rounded-2xl p-4 backdrop-blur">
               <div className="flex items-center gap-3 mb-2">

--- a/src/components/GamifiedDashboard.jsx
+++ b/src/components/GamifiedDashboard.jsx
@@ -23,7 +23,6 @@ import {
   ChevronRight,
   BarChart3,
   CheckCircle,
-  Maximize2,
 } from "lucide-react";
 import { useGamification } from "../context/GamificationContext";
 import { useAuth } from "../context/AuthContext";

--- a/src/components/GamifiedDashboard.jsx
+++ b/src/components/GamifiedDashboard.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { useNavigate } from "react-router-dom";
 import {
   Star,
   Trophy,

--- a/src/components/GamifiedDashboard.jsx
+++ b/src/components/GamifiedDashboard.jsx
@@ -56,7 +56,6 @@ const GamifiedDashboard = () => {
     achievements,
   } = useGamification();
   const { user } = useAuth();
-  const { toggleDashboard } = useDashboard();
 
   const [activeTab, setActiveTab] = useState("overview");
   const [showQuickActions, setShowQuickActions] = useState(false);

--- a/src/components/GamifiedDashboard.jsx
+++ b/src/components/GamifiedDashboard.jsx
@@ -23,6 +23,7 @@ import {
   ChevronRight,
   BarChart3,
   CheckCircle,
+  Maximize2,
 } from "lucide-react";
 import { useGamification } from "../context/GamificationContext";
 import { useAuth } from "../context/AuthContext";

--- a/src/components/GamifiedDashboard.jsx
+++ b/src/components/GamifiedDashboard.jsx
@@ -57,6 +57,7 @@ const GamifiedDashboard = () => {
     achievements,
   } = useGamification();
   const { user } = useAuth();
+  const { toggleDashboard } = useDashboard();
 
   const [activeTab, setActiveTab] = useState("overview");
   const [showQuickActions, setShowQuickActions] = useState(false);

--- a/src/components/GamifiedDashboard.jsx
+++ b/src/components/GamifiedDashboard.jsx
@@ -219,7 +219,7 @@ const GamifiedDashboard = () => {
                     <ul className="space-y-1 text-purple-700">
                       <li>• Earn gems from studying, quests, or jackpots.</li>
                       <li>• Spend gems on streak savers, boosts, or cosmetic upgrades.</li>
-                      <li>• Premium users get extra perks + higher rewards.</li>
+                      <li>��� Premium users get extra perks + higher rewards.</li>
                     </ul>
                   </div>
                 </div>
@@ -284,7 +284,14 @@ const GamifiedDashboard = () => {
 
             {/* Quick Actions */}
             <div className="flex items-center gap-3">
-              <button 
+              <button
+                onClick={toggleDashboard}
+                className="p-2 bg-white/20 hover:bg-white/30 rounded-xl transition-all"
+                title="Switch to classic dashboard"
+              >
+                <Maximize2 className="w-5 h-5" />
+              </button>
+              <button
                 onClick={() => setShowSettingsPopup(true)}
                 className="p-2 bg-white/20 hover:bg-white/30 rounded-xl transition-all"
               >

--- a/src/components/GamifiedDashboard.jsx
+++ b/src/components/GamifiedDashboard.jsx
@@ -725,42 +725,7 @@ const OverviewTab = ({ userStats, xpProgress, achievements, setActiveTab }) => {
       </div>
 
       {/* Premium Teaser */}
-      <div className="promo-gradient rounded-2xl shadow-xl p-8 text-white">
-        <div className="flex items-center justify-between">
-          <div>
-            <h3 className="text-2xl font-bold mb-2 flex items-center gap-2">
-              <Crown className="w-7 h-7 text-yellow-300" />
-              Unlock Premium Power
-            </h3>
-            <p className="text-purple-100 mb-4">
-              Get 3x XP multiplier, unlimited streak savers, and exclusive
-              themes!
-            </p>
-            <ul className="space-y-1 text-sm text-purple-100">
-              <li className="flex items-center gap-2">
-                <CheckCircle className="w-4 h-4 text-green-300" />
-                3x Faster Progress
-              </li>
-              <li className="flex items-center gap-2">
-                <CheckCircle className="w-4 h-4 text-green-300" />
-                Never Lose Your Streak
-              </li>
-              <li className="flex items-center gap-2">
-                <CheckCircle className="w-4 h-4 text-green-300" />
-                Exclusive Content & Themes
-              </li>
-            </ul>
-          </div>
-
-          <motion.button
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-            className="bg-white text-purple-600 px-8 py-4 rounded-xl font-bold shadow-lg hover:shadow-xl transition-all"
-          >
-            Upgrade Now
-          </motion.button>
-        </div>
-      </div>
+      
     </div>
   );
 };

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -14,19 +14,19 @@ export default function Sidebar() {
           <LayoutDashboardIcon className="w-5 h-5 text-white" />
         </div>
         <div className="absolute w-16 h-12 flex items-center justify-center transition-opacity duration-300 group-hover:opacity-0" style={{ top: '152px' }}>
-          <CalendarIcon className="w-5 h-5 text-white" />
-        </div>
-        <div className="absolute w-16 h-12 flex items-center justify-center transition-opacity duration-300 group-hover:opacity-0" style={{ top: '208px' }}>
-          <BookIcon className="w-5 h-5 text-white" />
-        </div>
-        <div className="absolute w-16 h-12 flex items-center justify-center transition-opacity duration-300 group-hover:opacity-0" style={{ top: '264px' }}>
-          <ListChecksIcon className="w-5 h-5 text-white" />
-        </div>
-        <div className="absolute w-16 h-12 flex items-center justify-center transition-opacity duration-300 group-hover:opacity-0" style={{ top: '320px' }}>
           <BrainIcon className="w-5 h-5 text-white" />
         </div>
-        <div className="absolute w-16 h-12 flex items-center justify-center transition-opacity duration-300 group-hover:opacity-0" style={{ top: '376px' }}>
+        <div className="absolute w-16 h-12 flex items-center justify-center transition-opacity duration-300 group-hover:opacity-0" style={{ top: '208px' }}>
           <BarChart3 className="w-5 h-5 text-white" />
+        </div>
+        <div className="absolute w-16 h-12 flex items-center justify-center transition-opacity duration-300 group-hover:opacity-0" style={{ top: '264px' }}>
+          <BookIcon className="w-5 h-5 text-white" />
+        </div>
+        <div className="absolute w-16 h-12 flex items-center justify-center transition-opacity duration-300 group-hover:opacity-0" style={{ top: '320px' }}>
+          <ListChecksIcon className="w-5 h-5 text-white" />
+        </div>
+        <div className="absolute w-16 h-12 flex items-center justify-center transition-opacity duration-300 group-hover:opacity-0" style={{ top: '376px' }}>
+          <CalendarIcon className="w-5 h-5 text-white" />
         </div>
         <div className="absolute w-16 h-12 flex items-center justify-center transition-opacity duration-300 group-hover:opacity-0" style={{ top: '432px' }}>
           <GraduationCap className="w-5 h-5 text-white" />

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -37,9 +37,13 @@ export default function Sidebar() {
           <LayoutDashboardIcon className="w-5 h-5 text-white opacity-1000" />
           <span className="text-white font-medium opacity-0 group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap">Dashboard</span>
         </Link>
-        <Link to="/schedule" className="flex items-center gap-3 px-6 py-3 focus:outline-none transition theme-hover-primary-10" title="Study Planner">
-          <CalendarIcon className="w-5 h-5 text-white" />
-          <span className="text-white font-medium opacity-0 group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap">Schedule</span>
+        <Link to="/study" className="flex items-center gap-3 px-6 py-3 focus:outline-none transition theme-hover-primary-10" title="Study">
+          <BrainIcon className="w-5 h-5 text-white" />
+          <span className="text-white font-medium opacity-0 group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap">Study</span>
+        </Link>
+        <Link to="/insights" className="flex items-center gap-3 px-6 py-3 focus:outline-none transition theme-hover-primary-10" title="Insights">
+          <BarChart3 className="w-5 h-5 text-white" />
+          <span className="text-white font-medium opacity-0 group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap">Insights</span>
         </Link>
         <Link to="/subjects" className="flex items-center gap-3 px-6 py-3 focus:outline-none transition theme-hover-primary-10" title="Subjects">
           <BookIcon className="w-5 h-5 text-white" />
@@ -49,13 +53,9 @@ export default function Sidebar() {
           <ListChecksIcon className="w-5 h-5 text-white" />
           <span className="text-white font-medium opacity-0 group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap">Tasks</span>
         </Link>
-        <Link to="/study" className="flex items-center gap-3 px-6 py-3 focus:outline-none transition theme-hover-primary-10" title="Study">
-          <BrainIcon className="w-5 h-5 text-white" />
-          <span className="text-white font-medium opacity-0 group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap">Study</span>
-        </Link>
-        <Link to="/insights" className="flex items-center gap-3 px-6 py-3 focus:outline-none transition theme-hover-primary-10" title="Insights">
-          <BarChart3 className="w-5 h-5 text-white" />
-          <span className="text-white font-medium opacity-0 group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap">Insights</span>
+        <Link to="/schedule" className="flex items-center gap-3 px-6 py-3 focus:outline-none transition theme-hover-primary-10" title="Study Planner">
+          <CalendarIcon className="w-5 h-5 text-white" />
+          <span className="text-white font-medium opacity-0 group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap">Schedule</span>
         </Link>
         <Link to="/resources" className="flex items-center gap-3 px-6 py-3 focus:outline-none transition theme-hover-primary-10" title="Resources">
           <GraduationCap className="w-5 h-5 text-white" />

--- a/src/context/DashboardContext.jsx
+++ b/src/context/DashboardContext.jsx
@@ -1,0 +1,25 @@
+import React, { createContext, useState, useContext } from 'react';
+
+const DashboardContext = createContext();
+
+export const DashboardProvider = ({ children }) => {
+  const [showGamified, setShowGamified] = useState(true);
+
+  const toggleDashboard = () => {
+    setShowGamified(prev => !prev);
+  };
+
+  return (
+    <DashboardContext.Provider value={{ showGamified, toggleDashboard }}>
+      {children}
+    </DashboardContext.Provider>
+  );
+};
+
+export const useDashboard = () => {
+  const context = useContext(DashboardContext);
+  if (!context) {
+    throw new Error('useDashboard must be used within DashboardProvider');
+  }
+  return context;
+};

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -243,6 +243,8 @@ export default function Dashboard() {
     <div className="min-h-screen bg-gradient-to-br from-[#1a1a2e] to-[#16213e] flex">
       <OnboardingModal userId={user?.id} />
 
+      {/* Main Content Container with Sidebar Offset */}
+      <div className="flex-1 pl-16">
       {/* Settings Popup */}
       <AnimatePresence>
         {showSettingsPopup && (
@@ -360,7 +362,7 @@ export default function Dashboard() {
         )}
       </AnimatePresence>
       {/* Main Content */}
-      <div className="flex-1">
+      <div>
         {/* Header Section */}
         <div className="flex justify-end gap-4 p-6 items-center">
           <DashboardViewToggle />
@@ -549,6 +551,7 @@ export default function Dashboard() {
       </div>
 
       
+      </div>
     </div>
   );
 }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -241,10 +241,8 @@ export default function Dashboard() {
   };
 
   return (
-     
-    <div className="min-h-screen bg-gradient-to-br from-[#1a1a2e] to-[#16213e] mt-20 flex">
+    <div className="min-h-screen bg-gradient-to-br from-[#1a1a2e] to-[#16213e] flex">
       <OnboardingModal userId={user?.id} />
-      <Sidebar />
 
       {/* Settings Popup */}
       <AnimatePresence>
@@ -363,7 +361,7 @@ export default function Dashboard() {
         )}
       </AnimatePresence>
       {/* Main Content */}
-      <div className="flex-1 ml-16 transition-all duration-300 ease-in-out [body>div>aside:hover_+_div&]:ml-64">
+      <div className="flex-1">
         {/* Header Section */}
         <div className="flex justify-end gap-3 p-6">
           <button

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -140,14 +140,14 @@ export default function Dashboard() {
     
     // Calculate total goal from all subjects
     const totalGoal = subjects.reduce((sum, subject) => sum + (subject.goalHours || 0), 0);
-    
+
     // Calculate actual hours studied this week
     const weekSessions = studySessions.filter(s => new Date(s.timestamp) >= weekStart);
     const minutesThisWeek = weekSessions.reduce((sum, s) => sum + (s.durationMinutes || 0), 0);
     const hoursThisWeek = minutesThisWeek / 60;
-    
+
     // Get accurate weekly statistics
-    const accurateStats = getAccurateWeeklyStats();
+    const accurateStats = getAccurateWeeklyStats(totalGoal);
 
     // Calculate streak
     const currentStreak = calculateStreak(studySessions);

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -362,14 +362,8 @@ export default function Dashboard() {
       {/* Main Content */}
       <div className="flex-1">
         {/* Header Section */}
-        <div className="flex justify-end gap-3 p-6">
-          <button
-            onClick={toggleDashboard}
-            className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-all text-white backdrop-blur"
-            title="Switch to gamified dashboard"
-          >
-            <Maximize2 className="w-5 h-5" />
-          </button>
+        <div className="flex justify-end gap-4 p-6 items-center">
+          <DashboardViewToggle />
           <button
             onClick={() => setShowSettingsPopup(true)}
             className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-all text-white backdrop-blur"

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -220,7 +220,7 @@ export default function Dashboard() {
   };
 
   // Calculate accurate weekly study statistics
-  const getAccurateWeeklyStats = () => {
+  const getAccurateWeeklyStats = (goal) => {
     const oneWeekAgo = new Date();
     oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
 
@@ -235,7 +235,7 @@ export default function Dashboard() {
     return {
       sessionsThisWeek: thisWeekSessions.length,
       hoursThisWeek: thisWeekMinutes / 60,
-      progress: totalGoal > 0 ? Math.min((thisWeekMinutes / 60 / totalGoal) * 100, 100) : 0
+      progress: goal > 0 ? Math.min((thisWeekMinutes / 60 / goal) * 100, 100) : 0
     };
   };
 

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -363,18 +363,21 @@ export default function Dashboard() {
       </AnimatePresence>
       {/* Main Content */}
       <div>
-        {/* Header Section */}
-        <div className="flex justify-end gap-4 p-6 items-center">
-          <DashboardViewToggle />
-          <button
-            onClick={() => setShowSettingsPopup(true)}
-            className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-all text-white backdrop-blur"
-            title="How the System Works"
-          >
-            <Settings className="w-5 h-5" />
-          </button>
+        {/* Dashboard View Toggle Section */}
+        <div className="flex justify-between items-center px-6 py-4 bg-white/5 border-b border-white/10">
+          <div></div>
+          <div className="flex items-center gap-4">
+            <DashboardViewToggle />
+            <button
+              onClick={() => setShowSettingsPopup(true)}
+              className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-all text-white backdrop-blur"
+              title="How the System Works"
+            >
+              <Settings className="w-5 h-5" />
+            </button>
+          </div>
         </div>
-        
+
         {/* Summary & Streak */}
         <section className="grid grid-cols-1 md:grid-cols-3 gap-6 px-6 py-8 bg-#F8F9FC">
           <Card title="This Week's Study">

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -6,8 +6,8 @@ import { motion, AnimatePresence } from "framer-motion";
 import Sidebar from "../components/Sidebar";
 import TimerCard from "../components/TimerCard";
 import OnboardingModal from "../components/OnboardingModal";
-import { useDashboard } from "../context/DashboardContext";
-import { FlameIcon, CheckCircle, Clock, XCircle, Trash2, Calendar, BookOpen, Zap, Settings, Maximize2 } from "lucide-react";
+import DashboardViewToggle from "../components/DashboardViewToggle";
+import { FlameIcon, CheckCircle, Clock, XCircle, Trash2, Calendar, BookOpen, Zap, Settings } from "lucide-react";
 
 function getStartOfWeek(date) {
   const d = new Date(date);

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -6,7 +6,8 @@ import { motion, AnimatePresence } from "framer-motion";
 import Sidebar from "../components/Sidebar";
 import TimerCard from "../components/TimerCard";
 import OnboardingModal from "../components/OnboardingModal";
-import { FlameIcon, CheckCircle, Clock, XCircle, Trash2, Calendar, BookOpen, Zap, Settings } from "lucide-react";
+import { useDashboard } from "../context/DashboardContext";
+import { FlameIcon, CheckCircle, Clock, XCircle, Trash2, Calendar, BookOpen, Zap, Settings, Maximize2 } from "lucide-react";
 
 function getStartOfWeek(date) {
   const d = new Date(date);

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -299,7 +299,7 @@ export default function Dashboard() {
                     </h3>
                     <ul className="space-y-1 text-orange-700">
                       <li>• Study every day to keep your streak alive.</li>
-                      <li>• Longer streaks = bigger XP boosts.</li>
+                      <li>��� Longer streaks = bigger XP boosts.</li>
                       <li>• Miss a day? Use a Streak Saver to protect your progress.</li>
                     </ul>
                   </div>
@@ -365,7 +365,14 @@ export default function Dashboard() {
       {/* Main Content */}
       <div className="flex-1 ml-16 transition-all duration-300 ease-in-out [body>div>aside:hover_+_div&]:ml-64">
         {/* Header Section */}
-        <div className="flex justify-end p-6">
+        <div className="flex justify-end gap-3 p-6">
+          <button
+            onClick={toggleDashboard}
+            className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-all text-white backdrop-blur"
+            title="Switch to gamified dashboard"
+          >
+            <Maximize2 className="w-5 h-5" />
+          </button>
           <button
             onClick={() => setShowSettingsPopup(true)}
             className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-all text-white backdrop-blur"

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -95,7 +95,6 @@ function getCompletedTasksThisWeek(tasks) {
 export default function Dashboard() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
-  const { toggleDashboard } = useDashboard();
   const [subjects, setSubjects] = useState([]);
   const [studySessions, setStudySessions] = useState([]);
   const [tasks, setTasks] = useState([]);

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -548,9 +548,7 @@ export default function Dashboard() {
           </button>
         </section>
         {/* Footer */}
-        <footer className="py-6 text-center bg-[#3F3D56] text-white mt-10">
-          <p>© 2025 Trackviso. Keep learning, keep growing!</p>
-        </footer>
+        
       </div>
 
       

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -95,6 +95,7 @@ function getCompletedTasksThisWeek(tasks) {
 export default function Dashboard() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
+  const { toggleDashboard } = useDashboard();
   const [subjects, setSubjects] = useState([]);
   const [studySessions, setStudySessions] = useState([]);
   const [tasks, setTasks] = useState([]);

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -618,50 +618,7 @@ const Landing = () => {
         </motion.div>
       </section>
 
-      {/* Footer */}
-      <footer className="bg-gray-900 text-white py-16 px-4">
-        <div className="max-w-7xl mx-auto">
-          <div className="grid md:grid-cols-4 gap-8 mb-12">
-            <div>
-              <div className="flex items-center space-x-2 mb-4">
-                <div className="w-8 h-8 bg-gradient-to-r from-emerald-500 to-blue-600 rounded-lg flex items-center justify-center">
-                  <Target className="w-5 h-5 text-white" />
-                </div>
-                <span className="text-xl font-bold">Trackviso</span>
-              </div>
-              <p className="text-gray-400 mb-6">
-                Empowering students to achieve academic excellence through intelligent tracking and insights.
-              </p>
-              
-            </div>
-            
-            <div>
-              <h4 className="font-semibold mb-4">Product</h4>
-              <div className="space-y-3 text-gray-400">
-                <button onClick={() => scrollToSection('features')} className="block hover:text-white transition-colors">Features</button>
-                <button onClick={() => scrollToSection('pricing')} className="block hover:text-white transition-colors">Pricing</button>
-                <button onClick={() => scrollToSection('demo')} className="block hover:text-white transition-colors">Demo</button>
-                
-              </div>
-            </div>
-            
-            
-            
-            <div>
-              <h4 className="font-semibold mb-4">Company</h4>
-              <div className="space-y-3 text-gray-400">
-                
-                <div className="hover:text-white transition-colors cursor-pointer">Privacy</div>
-                <div className="hover:text-white transition-colors cursor-pointer">Terms</div>
-              </div>
-            </div>
-          </div>
-          
-          <div className="border-t border-gray-800 pt-8 text-center text-gray-400">
-            <p>&copy; 2025 Trackviso. All rights reserved. Built with ❤️ for students.</p>
-          </div>
-        </div>
-      </footer>
+      
     </div>
   );
 };

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -9,6 +9,14 @@ export default function Privacy() {
   return (
     <div className="min-h-screen mt-20">
       <div className="p-8 max-w-4xl mx-auto">
+        {/* Dashboard View Toggle Section */}
+        <div className="flex justify-between items-center px-6 py-4 mb-8 bg-white/5 rounded-lg border border-white/10">
+          <div></div>
+          <div className="flex items-center gap-4">
+            <DashboardViewToggle />
+          </div>
+        </div>
+
         {/* Theme Selector */}
         <section className="mb-10">
           <h2 className="text-2xl font-bold mb-4 text-gray-900">Theme</h2>

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -10,7 +10,7 @@ export default function Privacy() {
     <div className="min-h-screen mt-20">
       <div className="p-8 max-w-4xl mx-auto">
         {/* Dashboard View Toggle Section */}
-        <div className="flex justify-between items-center px-6 py-4 mb-8 bg-white/5 rounded-lg border border-white/10">
+        <div className="flex justify-between items-center px-6 py-4 mb-8 bg-purple/5 rounded-lg border border-white/10">
           <div></div>
           <div className="flex items-center gap-4">
             <DashboardViewToggle />

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -11,7 +11,7 @@ export default function Privacy() {
       <div className="p-8 max-w-4xl mx-auto">
         {/* Dashboard View Toggle Section */}
         <div className="flex justify-between items-center px-6 py-4 mb-8 bg-black rounded-lg border border-black/10">
-          <div></div>
+          <div> <h2>Dashboard view</h2></div>
           <div className="flex items-center gap-4">
             <DashboardViewToggle />
           </div>

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -11,7 +11,7 @@ export default function Privacy() {
       <div className="p-8 max-w-4xl mx-auto">
         {/* Dashboard View Toggle Section */}
         <div className="flex justify-between items-center px-6 py-4 mb-8 bg-black rounded-lg border border-black/10">
-          <div> <h2>Dashboard view</h2></div>
+          <div> <h2 className="text-white">Dashboard view</h2></div>
           <div className="flex items-center gap-4">
             <DashboardViewToggle />
           </div>

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -10,7 +10,7 @@ export default function Privacy() {
     <div className="min-h-screen mt-20">
       <div className="p-8 max-w-4xl mx-auto">
         {/* Dashboard View Toggle Section */}
-        <div className="flex justify-between items-center px-6 py-4 mb-8 bg-purple/5 rounded-lg border border-white/10">
+        <div className="flex justify-between items-center px-6 py-4 mb-8 bg-purple/5 rounded-lg border border-black/10">
           <div></div>
           <div className="flex items-center gap-4">
             <DashboardViewToggle />

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { useTheme } from "../context/ThemeContext";
+import DashboardViewToggle from "../components/DashboardViewToggle";
+import { Settings } from "lucide-react";
 
 export default function Privacy() {
   const { theme, setTheme } = useTheme();

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -11,7 +11,7 @@ export default function Privacy() {
       <div className="p-8 max-w-4xl mx-auto">
         {/* Dashboard View Toggle Section */}
         <div className="flex justify-between items-center px-6 py-4 mb-8 bg-black rounded-lg border border-black/10">
-          <div> <h2 className="text-white">Dashboard view</h2></div>
+          <div> <h2 className="text-white font-bold">Dashboard view</h2></div>
           <div className="flex items-center gap-4">
             <DashboardViewToggle />
           </div>

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -10,7 +10,7 @@ export default function Privacy() {
     <div className="min-h-screen mt-20">
       <div className="p-8 max-w-4xl mx-auto">
         {/* Dashboard View Toggle Section */}
-        <div className="flex justify-between items-center px-6 py-4 mb-8 bg-purple/5 rounded-lg border border-black/10">
+        <div className="flex justify-between items-center px-6 py-4 mb-8 bg-black/5 rounded-lg border border-black/10">
           <div></div>
           <div className="flex items-center gap-4">
             <DashboardViewToggle />

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -10,7 +10,7 @@ export default function Privacy() {
     <div className="min-h-screen mt-20">
       <div className="p-8 max-w-4xl mx-auto">
         {/* Dashboard View Toggle Section */}
-        <div className="flex justify-between items-center px-6 py-4 mb-8 bg-black/2 rounded-lg border border-black/10">
+        <div className="flex justify-between items-center px-6 py-4 mb-8 bg-black rounded-lg border border-black/10">
           <div></div>
           <div className="flex items-center gap-4">
             <DashboardViewToggle />

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -10,7 +10,7 @@ export default function Privacy() {
     <div className="min-h-screen mt-20">
       <div className="p-8 max-w-4xl mx-auto">
         {/* Dashboard View Toggle Section */}
-        <div className="flex justify-between items-center px-6 py-4 mb-8 bg-black/5 rounded-lg border border-black/10">
+        <div className="flex justify-between items-center px-6 py-4 mb-8 bg-black/2 rounded-lg border border-black/10">
           <div></div>
           <div className="flex items-center gap-4">
             <DashboardViewToggle />

--- a/src/pages/Subjects.jsx
+++ b/src/pages/Subjects.jsx
@@ -107,7 +107,7 @@ const Subjects = () => {
       <div className="flex items-center justify-between mb-8">
         <div>
           <h1 className="text-3xl font-bold text-white">Subjects</h1>
-          <p className="text-gray-600">Manage your study subjects and track progress</p>
+          <p className="text-white">Manage your study subjects and track progress</p>
         </div>
         <motion.button
           whileHover={{ scale: 1.05 }}

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = "1.1";
+export const APP_VERSION = "0.1 beta test";


### PR DESCRIPTION
### Purpose

The user wants to introduce a feature that allows switching between a "Full" (gamified) and a "Basic" dashboard view. This toggle should be available on both the main dashboard and the privacy page, ensuring the user's choice is consistent across the app. Additionally, the user requested to make the "Current Streak" and "Study Time" cards on the full dashboard interactive, linking them to the insights page and providing a clear call-to-action on hover.

### Code changes

- **Dashboard View Toggle**: Implemented a `DashboardContext` to manage the state of the dashboard view. A new `DashboardViewToggle` component has been created and added to the `GamifiedDashboard`, `Dashboard`, and `Privacy` pages to allow users to switch between the "Full" and "Basic" views.
- **App Structure**: Wrapped the main application router in a `DashboardProvider` to make the view state globally accessible. A new `DashboardToggle` functional component in `App.jsx` now conditionally renders either the `GamifiedDashboard` or the `Dashboard` based on the context.
- **Interactive Stat Cards**: The "Current Streak" and "Study Time" cards in the `GamifiedDashboard` are now clickable. On hover, the cards darken and display a "Click to see more" message. Clicking a card navigates the user to the `/insights` page.
- **Layout Fix**: Adjusted the main content layout in the `Dashboard` to correctly offset for the sidebar width, preventing components from being hidden.


To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0bd02ef968ac4ff1a05c48f5f228713f/zenith-works)

👀 [Preview Link](https://0bd02ef968ac4ff1a05c48f5f228713f-zenith-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0bd02ef968ac4ff1a05c48f5f228713f</projectId>-->
<!--<branchName>zenith-works</branchName>-->